### PR TITLE
Adding distance tooltip in right angle digitalization tool

### DIFF
--- a/ProductionTools/Acquisition/distanceToolTip.py
+++ b/ProductionTools/Acquisition/distanceToolTip.py
@@ -1,0 +1,48 @@
+from toolTip import ToolTip
+from qgis.core import QgsDistanceArea, QgsCoordinateReferenceSystem
+from qgis.core import QgsProject 
+from PyQt4.QtGui import QToolTip, QColor, QFont
+from PyQt4.QtCore import QPoint
+
+class DistanceToolTip(ToolTip):
+	def __init__(self, iface):
+		super(DistanceToolTip, self).__init__(iface)
+		self.iface = iface
+		self.canvas = iface.mapCanvas()      
+		self.last_distance = 0  
+		self.showing = False	
+			
+
+	def calculateDistance(self, p1, p2):
+		distance = QgsDistanceArea()
+		distance.setSourceCrs(self.iface.activeLayer().crs())
+		distance.setEllipsoidalMode(True)
+		# Sirgas 2000
+		distance.setEllipsoid('GRS1980')
+		m = distance.measureLine(p1, p2) 
+		return m
+
+	def canvasMoveEvent(self, last_p, current_p):
+		m =  int(self.calculateDistance(last_p, current_p))		
+		
+		if self.showing:
+			if m != self.last_distance:
+				color = 'red'
+				if m >= 4:
+					color = 'green'				
+				txt = "<p style='color:{color}'><b>{distance}</b></p>".format(color=color, distance=str(m))
+				super(DistanceToolTip, self).show(txt, current_p)		
+				self.last_distance = m  
+		else:
+			if m > 1:
+				color = 'red'
+				if m >= 4:
+					color = 'green'				
+				txt = "<p style='color:{color}'><b>{distance}</b></p>".format(color=color, distance=str(m))
+				super(DistanceToolTip, self).show(txt, current_p)		  	
+				self.last_distance = m
+				self.showing = True
+
+   	def deactivate(self):
+   		super(DistanceToolTip, self).deactivate()
+   		self.showing = False

--- a/ProductionTools/Acquisition/distanceToolTip.py
+++ b/ProductionTools/Acquisition/distanceToolTip.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ DsgTools
+                                 A QGIS plugin
+ Brazilian Army Cartographic Production Tools
+                             -------------------
+        begin                : 2018-05-23
+        git sha              : $Format:%H$
+        copyright            : (C) 2018 by Ronaldo Martins da Silva Junior - Cartographic Engineer @ Brazilian Army
+        email                : ronaldomartins.silva@eb.mil.br
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
 from toolTip import ToolTip
 from qgis.core import QgsDistanceArea, QgsCoordinateReferenceSystem
 from qgis.core import QgsProject 

--- a/ProductionTools/Acquisition/geometricaAquisition.py
+++ b/ProductionTools/Acquisition/geometricaAquisition.py
@@ -9,6 +9,7 @@ import math
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtGui import QShortcut, QKeySequence, QCursor, QPixmap, QColor
 from PyQt4.QtCore import QSettings
+from distanceToolTip import DistanceToolTip
 
 class GeometricaAcquisition(QgsMapToolAdvancedDigitizing):
     def __init__(self, canvas, iface, action):
@@ -19,6 +20,7 @@ class GeometricaAcquisition(QgsMapToolAdvancedDigitizing):
         self.snapCursorRubberBand = None
         self.initVariable()
         self.setAction(action)
+        self.distanceToolTip = DistanceToolTip(self.iface)
 
     def getSuppressOptions(self):
         qgisSettigns = QSettings()

--- a/ProductionTools/Acquisition/polygon.py
+++ b/ProductionTools/Acquisition/polygon.py
@@ -11,6 +11,7 @@ from PyQt4.QtCore import QSettings
 from geometricaAquisition import GeometricaAcquisition
 from qgis.core import QgsPoint, QGis, QgsGeometry
 from qgis.gui import QgsMapMouseEvent, QgsMapTool
+from distanceToolTip import DistanceToolTip
 
 class Polygon(GeometricaAcquisition):
     def __init__(self, canvas, iface, action):
@@ -83,9 +84,11 @@ class Polygon(GeometricaAcquisition):
             self.createSnapCursor(point)
         point = QgsPoint(event.mapPoint())   
         if self.qntPoint == 1:
+            self.distanceToolTip.canvasMoveEvent(self.geometry[0], point)
             geom = QgsGeometry.fromPolyline([self.geometry[0], point])
             self.rubberBand.setToGeometry(geom, None)
         elif self.qntPoint >= 2:
+            self.distanceToolTip.canvasMoveEvent(self.geometry[-1], point)
             if self.free:
                 geom = QgsGeometry.fromPolygon([self.geometry+[QgsPoint(point.x(), point.y())]])
                 self.rubberBand.setToGeometry(geom, None)             

--- a/ProductionTools/Acquisition/polygon.py
+++ b/ProductionTools/Acquisition/polygon.py
@@ -11,7 +11,6 @@ from PyQt4.QtCore import QSettings
 from geometricaAquisition import GeometricaAcquisition
 from qgis.core import QgsPoint, QGis, QgsGeometry
 from qgis.gui import QgsMapMouseEvent, QgsMapTool
-from distanceToolTip import DistanceToolTip
 
 class Polygon(GeometricaAcquisition):
     def __init__(self, canvas, iface, action):

--- a/ProductionTools/Acquisition/toolTip.py
+++ b/ProductionTools/Acquisition/toolTip.py
@@ -1,0 +1,15 @@
+from PyQt4.QtGui import QToolTip, QFont, QColor, QPalette
+from PyQt4.QtCore import QPoint
+
+
+class ToolTip(object):
+	def __init__(self, iface):
+		self.iface = iface
+		self.canvas = iface.mapCanvas()		
+   		   
+	def show(self, text, toolTipPoint):
+		QToolTip.showText(self.canvas.mapToGlobal(self.canvas.mouseLastXY()),str(text), self.canvas)		
+
+   	def deactivate(self):
+   		QToolTip.hideText()
+


### PR DESCRIPTION
This commit adds a tooltip with the segment distance for the right angle  digitalization tool.
For segments shorter or equal 4 meters the distance is shown in red color [RGB(255,0,0)], and for segments bigger than 4 meters the distance is shown in green color [RGB (0,128,0)].