### PR TITLE
Setting rectangular shape for right angle digitalization tool

### DIFF
--- a/ProductionTools/Acquisition/geometricaAquisition.py
+++ b/ProductionTools/Acquisition/geometricaAquisition.py
@@ -103,7 +103,7 @@ class GeometricaAcquisition(QgsMapToolAdvancedDigitizing):
             self.snapCursorRubberBand = None
 
     def completePolygon(self,geom, p4):                
-        if len(geom) % 2 == 0:
+        if (len(geom)>=2) and (len(geom) % 2 == 0):
             p1      = geom[1]
             p2      = geom[0]
             p3      = geom[-1]

--- a/ProductionTools/Acquisition/geometricaAquisition.py
+++ b/ProductionTools/Acquisition/geometricaAquisition.py
@@ -101,7 +101,19 @@ class GeometricaAcquisition(QgsMapToolAdvancedDigitizing):
             self.snapCursorRubberBand.reset(geometryType=QGis.Point)
             self.snapCursorRubberBand.hide()
             self.snapCursorRubberBand = None
-    
+
+    def completePolygon(self,geom, p4):                
+        if len(geom) % 2 == 0:
+            p1      = geom[1]
+            p2      = geom[0]
+            p3      = geom[-1]
+            pf = self.lineIntersection(p1, p2, p3, p4)
+            new_geom = QgsGeometry.fromPolygon([self.geometry+[p4, pf]])                            
+        else:
+            new_geom = QgsGeometry.fromPolygon([self.geometry+[QgsPoint(p4.x(), p4.y())]])            
+            pf = p4            
+        return new_geom, pf
+            
     def lineIntersection(self, p1, p2, p3, p4):        
         m1 = (p1.y() - p2.y())/(p1.x() - p2.x())
         a1 = p2.y() + p2.x()/m1

--- a/ProductionTools/Acquisition/polygon.py
+++ b/ProductionTools/Acquisition/polygon.py
@@ -20,14 +20,12 @@ class Polygon(GeometricaAcquisition):
 
     def endGeometry(self):
         if len(self.geometry) > 2:
-            inter = self.lineIntersection(self.geometry[1],self.geometry[0],self.geometry[-2],self.geometry[-1])
-            if inter:
-                if self.iface.activeLayer().geometryType() == QGis.Polygon:
-                    geom = QgsGeometry.fromPolygon([self.geometry+[inter]])
-                elif self.iface.activeLayer().geometryType() == QGis.Line:
-                    geom = QgsGeometry.fromPolyline(self.geometry+[inter])
-                self.rubberBand.setToGeometry(geom,None)
-                self.createGeometry(geom)
+            if self.iface.activeLayer().geometryType() == QGis.Polygon:
+                geom = QgsGeometry.fromPolygon([self.geometry])
+            elif self.iface.activeLayer().geometryType() == QGis.Line:
+                geom = QgsGeometry.fromPolygon([self.geometry])
+            self.rubberBand.setToGeometry(geom,None)
+            self.createGeometry(geom)
 
     def endGeometryFree(self):
         if len(self.geometry) > 2:
@@ -51,6 +49,13 @@ class Polygon(GeometricaAcquisition):
                 self.geometry.append(pointMap)
                 self.endGeometryFree()
             else:
+                if (self.qntPoint >=2) and (self.qntPoint % 2 == 0):
+                    point = QgsPoint(pointMap)
+                    testgeom = self.projectPoint(self.geometry[-2], self.geometry[-1], point)
+                    if testgeom:
+                        new_geom, pf = self.completePolygon(self.geometry, testgeom)
+                        self.geometry.append(QgsPoint(testgeom.x(), testgeom.y()))        
+                        self.geometry.append(pf)                    
                 self.endGeometry()        
         elif self.free:
             self.geometry.append(pointMap)
@@ -94,5 +99,5 @@ class Polygon(GeometricaAcquisition):
             else:        
                 testgeom = self.projectPoint(self.geometry[-2], self.geometry[-1], point)
                 if testgeom:
-                    geom = QgsGeometry.fromPolygon([self.geometry+[QgsPoint(testgeom.x(), testgeom.y())]])
+                    geom, pf = self.completePolygon(self.geometry, testgeom)
                     self.rubberBand.setToGeometry(geom, None)

--- a/ProductionTools/Acquisition/polygon.py
+++ b/ProductionTools/Acquisition/polygon.py
@@ -23,7 +23,7 @@ class Polygon(GeometricaAcquisition):
             if self.iface.activeLayer().geometryType() == QGis.Polygon:
                 geom = QgsGeometry.fromPolygon([self.geometry])
             elif self.iface.activeLayer().geometryType() == QGis.Line:
-                geom = QgsGeometry.fromPolygon([self.geometry])
+                geom = QgsGeometry.fromPolyline(self.geometry)
             self.rubberBand.setToGeometry(geom,None)
             self.createGeometry(geom)
 
@@ -49,13 +49,19 @@ class Polygon(GeometricaAcquisition):
                 self.geometry.append(pointMap)
                 self.endGeometryFree()
             else:
-                if (self.qntPoint >=2) and (self.qntPoint % 2 == 0):
-                    point = QgsPoint(pointMap)
-                    testgeom = self.projectPoint(self.geometry[-2], self.geometry[-1], point)
-                    if testgeom:
-                        new_geom, pf = self.completePolygon(self.geometry, testgeom)
-                        self.geometry.append(QgsPoint(testgeom.x(), testgeom.y()))        
-                        self.geometry.append(pf)                    
+                if (self.qntPoint >=2):
+                    if (self.qntPoint % 2 == 0):
+                        point = QgsPoint(pointMap)
+                        testgeom = self.projectPoint(self.geometry[-2], self.geometry[-1], point)
+                        if testgeom:
+                            new_geom, pf = self.completePolygon(self.geometry, testgeom)
+                            self.geometry.append(QgsPoint(testgeom.x(), testgeom.y()))        
+                            self.geometry.append(pf)                    
+                    else:
+                        point = QgsPoint(pointMap)
+                        testgeom = self.projectPoint(self.geometry[-2], self.geometry[-1], point)
+                        if testgeom:                                
+                            self.geometry.append(QgsPoint(testgeom.x(), testgeom.y()))                   
                 self.endGeometry()        
         elif self.free:
             self.geometry.append(pointMap)


### PR DESCRIPTION
This commit makes rectangular shape default for the right angle digitalization tool in order to help the visualization of the feature.
There is change in the number of clicks needed for setting the feature. 
After the second point the user will be able to see the rectangle shape and in the next right click save the feature.