### PR TITLE
styles can be loaded from DB

### DIFF
--- a/core/Factories/DbFactory/postgisDb.py
+++ b/core/Factories/DbFactory/postgisDb.py
@@ -1870,7 +1870,13 @@ class PostgisDb(AbstractDb):
         if parsing:
             if qml:
                 qml = self.utils.parseStyle(qml)
-        return qml
+        tempPath = None
+        if qml:
+            tempPath = os.path.join(os.path.dirname(__file__), 'temp.qml')
+            with open(tempPath, 'w') as f:
+                f.writelines(qml)
+                f.close()
+        return tempPath
     
     def importStyle(self, styleName, table_name, qml, tableSchema, useTransaction = True):
         self.checkAndOpenDb()

--- a/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
@@ -71,12 +71,18 @@ class EDGVLayerLoader(QObject):
             return self.getStyleFromFile(stylePath['style'], className)
     
     def getStyleFromFile(self, stylePath, className):
-        availableStyles = os.walk(stylePath).next()[2]
+        availableStyles = next(os.walk(stylePath))[2]
         styleName = className+'.qml'
         if styleName in availableStyles:
             path = os.path.join(stylePath, styleName)
             qml = self.utils.parseStyle(path)
-            return qml
+            # dsgtools have the right to write on its own directory
+            # a temporary file "temp.qml"
+            tempPath = os.path.join(stylePath, "temp.qml")
+            with open(tempPath, "w") as f:
+                f.writelines(qml)
+                f.close()
+            return tempPath
         else:
             return None
     

--- a/core/Factories/LayerLoaderFactory/postgisLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/postgisLayerLoader.py
@@ -214,7 +214,11 @@ class PostGISLayerLoader(EDGVLayerLoader):
             if stylePath:
                 fullPath = self.getStyle(stylePath, tableName)
                 if fullPath:
-                    vlayer.applyNamedStyle(fullPath)
+                    vlayer.loadNamedStyle(fullPath)
+                    # remove qml temporary file
+                    self.utils.deleteQml(fullPath)
+                    # clear fullPath variable
+                    del fullPath
             if customForm:
                 vlayer = self.loadFormCustom(vlayer)
             parentNode.addLayer(vlayer)

--- a/core/Utils/utils.py
+++ b/core/Utils/utils.py
@@ -255,7 +255,7 @@ class Utils(object):
         Deletes a file from a given dir, if it's a QML file.
         """
         try:
-            if temp[-4:].lower() == '.qml':
+            if tempQml[-4:].lower() == '.qml':
                 try:
                     # linux/unix env
                     os.system('rm {0}'.format(tempQml))

--- a/gui/LayerTools/LoadLayersFromServer/loadLayersFromServer.py
+++ b/gui/LayerTools/LoadLayersFromServer/loadLayersFromServer.py
@@ -134,23 +134,16 @@ class LoadLayersFromServer(QtWidgets.QDialog, FORM_CLASS):
         if len(selectedKeys) == 0:
             QMessageBox.information(self, self.tr('Error!'), self.tr('Select at least one layer to be loaded!'))
             return
-
         #2- get parameters
         withElements = self.checkBoxOnlyWithElements.isChecked()
         selectedStyle = None
         edgvVersion = self.customServerConnectionWidget.getDatabaseVersion()
-        if edgvVersion == 'Non_EDGV':
-            isEdgv = False
-        else:
-            isEdgv = True
+        isEdgv = not edgvVersion == 'Non_EDGV'
         if self.styleComboBox.currentIndex() != 0:
             selectedStyle = self.customServerConnectionWidget.stylesDict[self.styleComboBox.currentText()]
         uniqueLoad = self.uniqueLoadCheckBox.isChecked()
         onlyParents = self.onlyParentsCheckBox.isChecked()
-        if 'Pro' in edgvVersion:
-            customForm = True if not self.customFormCheckBox.isChecked() else False
-        else:
-            customForm = False
+        customForm = not self.customFormCheckBox.isChecked() if 'Pro' in edgvVersion else False
         #3- Build factory dict
         factoryDict = dict()
         dbList = list(self.customServerConnectionWidget.selectedDbsDict.keys())
@@ -159,13 +152,13 @@ class LoadLayersFromServer(QtWidgets.QDialog, FORM_CLASS):
         #4- load for each db
         exceptionDict = dict()
         progress = ProgressWidget(1, len(dbList), self.tr('Loading layers from selected databases... '), parent=self)
-        for dbName in list(factoryDict.keys()):
+        for dbName in factoryDict:
             QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
             try:
                 selectedClasses = []
                 for i in selectedKeys:
-                    if i in list(self.lyrDict.keys()):
-                        if dbName in list(self.lyrDict[i].keys()):
+                    if i in self.lyrDict:
+                        if dbName in self.lyrDict[i]:
                             selectedClasses.append(self.lyrDict[i][dbName])
                 factoryDict[dbName].load(selectedClasses, uniqueLoad=uniqueLoad, onlyWithElements=withElements, stylePath=selectedStyle, useInheritance=onlyParents, isEdgv=isEdgv, customForm = customForm, parent=self)
                 progress.step()


### PR DESCRIPTION
new approach (creating a temp.qml file) implemented. Note that there is an open ([19651](https://issues.qgis.org/issues/19651)) issue on QGIS project that does not allow styles to be re-applied from .QML files if there styles stored into DB.