### PR TITLE
CodeList refactor.

### DIFF
--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
@@ -20,19 +20,14 @@
  *                                                                         *
  ***************************************************************************/
 """
-from builtins import str
-from builtins import map
 from collections import defaultdict
 import os
 
-# Qt imports
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import pyqtSlot
-
-# QGIS imports
-from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsProject
 from qgis.PyQt.QtWidgets import QTableWidgetItem, QDockWidget
 from qgis.PyQt.QtSql import QSqlDatabase, QSqlQuery
+from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsProject
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'code_list.ui'))

--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
@@ -316,7 +316,7 @@ class CodeList(QtWidgets.QDockWidget, FORM_CLASS):
         Populates field map to codelist table.
         """
         # always prefer EDGV domain tables, if available
-        fieldMap = self.getEdgvDomains() or self.currentFieldMap()
+        fieldMap = self.currentFieldMap()
         self.tableWidget.setRowCount(len(fieldMap))
         for row, (code, value) in enumerate(fieldMap.items()):
             self.tableWidget.setItem(row, 0, QTableWidgetItem(value))

--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
@@ -26,19 +26,18 @@ from collections import defaultdict
 import os
 
 # Qt imports
-from qgis.PyQt import QtWidgets, uic, QtCore
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, Qt
+from qgis.PyQt import uic
+from qgis.PyQt.QtCore import pyqtSlot
 
 # QGIS imports
-from qgis.core import QgsMapLayer, QgsField, QgsDataSourceUri, QgsMessageLog,\
-                      QgsVectorLayer, Qgis, QgsProject
-from qgis.PyQt.QtWidgets import QTableWidgetItem, QMessageBox
+from qgis.core import QgsDataSourceUri, QgsVectorLayer, QgsProject
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QDockWidget
 from qgis.PyQt.QtSql import QSqlDatabase, QSqlQuery
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'code_list.ui'))
 
-class CodeList(QtWidgets.QDockWidget, FORM_CLASS):
+class CodeList(QDockWidget, FORM_CLASS):
     def __init__(self, iface):
         """Constructor."""
         super(CodeList, self).__init__()
@@ -286,13 +285,12 @@ class CodeList(QtWidgets.QDockWidget, FORM_CLASS):
                     db.setDatabaseName(uri.database())
                     db.setUserName(uri.username())
                     db.setPassword(uri.password())
-                    sql = 'select code, code_name from dominios.{field} order by code'.format(field=self.currentField())    
+                    sql = 'select code, code_name from dominios.{field} order by code'.format(field=(field or self.currentField()))    
                 if not db.open():
                     db.close()
                     return ret
                 query = QSqlQuery(sql, db)
                 if not query.isActive():
-                    # QMessageBox.critical(self.iface.mainWindow(), self.tr("Error!"), self.tr("Problem obtaining domain values: ")+query.lastError().text())
                     return ret       
                 while query.next():
                     code = str(query.value(0))
@@ -315,7 +313,6 @@ class CodeList(QtWidgets.QDockWidget, FORM_CLASS):
         """
         Populates field map to codelist table.
         """
-        # always prefer EDGV domain tables, if available
         fieldMap = self.currentFieldMap()
         self.tableWidget.setRowCount(len(fieldMap))
         for row, (code, value) in enumerate(fieldMap.items()):

--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.ui
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.ui
@@ -67,6 +67,12 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="text">
            <string>Class</string>
           </property>
@@ -80,6 +86,12 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="text">
            <string>Field</string>
           </property>
@@ -92,7 +104,7 @@
         <item>
          <widget class="DsgCustomComboBox" name="classComboBox" native="true">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -102,7 +114,7 @@
         <item>
          <widget class="DsgCustomComboBox" name="comboBox" native="true">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>

--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.ui
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.ui
@@ -21,66 +21,27 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string>Class</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="DsgCustomComboBox" name="classComboBox" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-     </widget>
-    </item>
     <item row="1" column="0">
-     <widget class="QLabel" name="label">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
-      <property name="text">
-       <string>Field</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="DsgCustomComboBox" name="comboBox" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0" colspan="2">
-     <widget class="QPushButton" name="refreshButton">
-      <property name="minimumSize">
+      <property name="sizeHint" stdset="0">
        <size>
-        <width>170</width>
-        <height>34</height>
+        <width>40</width>
+        <height>20</height>
        </size>
       </property>
+     </spacer>
+    </item>
+    <item row="1" column="1">
+     <widget class="QPushButton" name="refreshButton">
       <property name="text">
        <string>Reload</string>
       </property>
      </widget>
     </item>
-    <item row="3" column="0" colspan="2">
+    <item row="2" column="0" colspan="2">
      <widget class="QTableWidget" name="tableWidget">
       <column>
        <property name="text">
@@ -93,6 +54,64 @@
        </property>
       </column>
      </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Class</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Field</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="DsgCustomComboBox" name="classComboBox" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="DsgCustomComboBox" name="comboBox" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
Refactor da CodeList toolbox.

Código foi todo revisado. Manteve-se a leitura de tabelas de domínio para modelos EDGV, que continuam sendo favorecidas em detrimento da leitura OTF (próximo passo talvez fosse alterar este método).

Conserta o _bug_ de não conseguir ler usar a _toolbox_ para bases de dados que não a PostgreSQL.