### PR TITLE
toolboxes are created as requested now

### DIFF
--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
@@ -39,19 +39,6 @@ class CodeList(QDockWidget, FORM_CLASS):
         self.setupUi(self)
         self.iface = iface
         self.setInitialState()
-    
-    def addTool(self, manager, callback, parentMenu, iconBasePath, parentStackButton):
-        icon_path = iconBasePath + 'codelist.png'
-        text = self.tr('View Code List Codes and Values')
-        action = manager.add_action(
-            icon_path,
-            text=text,
-            callback=callback,
-            add_to_menu=False,
-            add_to_toolbar=False,
-            parentMenu = parentMenu,
-            parentButton = parentStackButton
-            )
 
     def blockAllSignals(self, status):
         """

--- a/gui/ProductionTools/Toolboxes/ComplexTools/complexWindow.py
+++ b/gui/ProductionTools/Toolboxes/ComplexTools/complexWindow.py
@@ -62,19 +62,6 @@ class ComplexWindow(QtWidgets.QDockWidget, FORM_CLASS):
         self.abstractDb = None
         self.databases = None
         self.abstractDbFactory = DbFactory()
-    
-    def addTool(self, manager, callback, parentMenu, iconBasePath, parentStackButton):
-        icon_path = iconBasePath + 'complex.png'
-        text = self.tr('Build Complex Structures')
-        action = manager.add_action(
-            icon_path,
-            text=text,
-            callback=callback,
-            add_to_menu=False,
-            add_to_toolbar=False,
-            parentMenu = parentMenu,
-            parentButton = parentStackButton
-            )
 
     def __del__(self):
         """

--- a/gui/ProductionTools/Toolboxes/ContourTool/calc_contour.py
+++ b/gui/ProductionTools/Toolboxes/ContourTool/calc_contour.py
@@ -66,19 +66,6 @@ class CalcContour(QtWidgets.QDockWidget, FORM_CLASS):
         QgsProject.instance().layersAdded.connect(self.addLayers)
         QgsProject.instance().layersRemoved.connect(self.populateLayers)
 
-    def addTool(self, manager, callback, parentMenu, iconBasePath, parentStackButton):
-        icon_path = iconBasePath + 'calccontour.png'
-        text = self.tr('Assign Contour Values')
-        action = manager.add_action(
-            icon_path,
-            text=text,
-            callback=callback,
-            add_to_menu=False,
-            add_to_toolbar=False,
-            parentMenu = parentMenu,
-            parentButton = parentStackButton
-            )
-
     @pyqtSlot(bool, name = 'on_reactivatePushButton_clicked')
     def activateTool(self):
         """

--- a/gui/ProductionTools/Toolboxes/FieldToolBox/field_toolbox.py
+++ b/gui/ProductionTools/Toolboxes/FieldToolBox/field_toolbox.py
@@ -62,20 +62,6 @@ class FieldToolbox(QtWidgets.QDockWidget, FORM_CLASS):
         self.addedFeatures = []
         self.configFromDbDict = dict()
         self.layerHandler = LayerHandler(iface)
-
-    def addTool(self, manager, callback, parentMenu, iconBasePath, parentStackButton):
-        icon_path = iconBasePath + 'fieldToolbox.png'
-        text = self.tr('Feature Classification Tool')
-        action = manager.add_action(
-            icon_path,
-            text=text,
-            callback=callback,
-            add_to_menu=False,
-            add_to_toolbar=False,
-            parentMenu = parentMenu,
-            parentButton = parentStackButton
-            )
-        parentStackButton.setDefaultAction(action)
     
     def defineFactory(self, abstractDb):
         """

--- a/gui/ProductionTools/Toolboxes/toolBoxesGuiManager.py
+++ b/gui/ProductionTools/Toolboxes/toolBoxesGuiManager.py
@@ -49,15 +49,29 @@ class ToolBoxesGuiManager(QObject):
     def initGui(self):
         #self.validationToolbox = ValidationToolbox(self.iface)
         #self.validationToolbox.addTool(self.manager, self.showValidationToolbox, self.parentMenu, self.iconBasePath, self.stackButton)
-        self.fieldToolbox = FieldToolbox(self.iface)
-        self.fieldToolbox.addTool(self.manager, self.showFieldToolbox, self.parentMenu, self.iconBasePath, self.stackButton)
-        self.calcContour = CalcContour(self.iface)
-        self.calcContour.addTool(self.manager, self.showCalcContourToolbox, self.parentMenu, self.iconBasePath, self.stackButton)
-        self.codeList = CodeList(self.iface)
-        self.codeList.addTool(self.manager, self.showCodeList, self.parentMenu, self.iconBasePath, self.stackButton)
-        self.complexWindow = ComplexWindow(self.iface)
-        self.complexWindow.addTool(self.manager, self.showComplexDock, self.parentMenu, self.iconBasePath, self.stackButton)
-    
+        self.fieldToolbox = None
+        self.addTool(self.showFieldToolbox, 'fieldToolbox.png', self.tr('Feature Classification Tool'), setDefaultAction=True)
+        self.calcContour = None
+        self.addTool(self.showCalcContourToolbox, 'calccontour.png', self.tr('Assign Contour Values'))
+        self.codeList = None
+        self.addTool(self.showCodeList, 'codelist.png', self.tr('View Code List Codes and Values'))
+        self.complexWindow = None
+        self.addTool(self.showComplexDock, 'complex.png', self.tr('Build Complex Structures'))
+
+    def addTool(self, callback, iconBaseName, text, setDefaultAction=False):
+        action = self.manager.add_action(
+            os.path.join(self.iconBasePath, iconBaseName),
+            text=text,
+            callback=callback,
+            add_to_menu=False,
+            add_to_toolbar=False,
+            parentMenu = self.parentMenu,
+            parentButton = self.stackButton
+        )
+        if setDefaultAction:
+            self.stackButton.setDefaultAction(action)
+        return action
+
     def unload(self):
         pass
 
@@ -67,6 +81,8 @@ class ToolBoxesGuiManager(QObject):
         """
         if self.codeList:
             self.iface.removeDockWidget(self.codeList)
+        else:
+            self.codeList = CodeList(self.iface)
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.codeList)
 
     def showFieldToolbox(self):


### PR DESCRIPTION
Movi o método de adição de ferramentas ao manager, de modo que o objeto não precisa ser instanciado para ser adicionado à interface.