### PR TITLE
Update aboutdialog.py

### DIFF
--- a/gui/AboutAndFurtherInfo/aboutdialog.py
+++ b/gui/AboutAndFurtherInfo/aboutdialog.py
@@ -25,8 +25,8 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog
 
 # replace version from metada file
-with open(os.path.join(os.path.dirname(__file__), 'ui_about.ui'), 'r') as about, \
-     open(os.path.join(os.path.dirname(__file__), '..', '..', 'metadata.txt'), 'r') as meta, \
+with open(os.path.join(os.path.dirname(__file__), 'ui_about.ui'), 'r', encoding="utf-8") as about, \
+     open(os.path.join(os.path.dirname(__file__), '..', '..', 'metadata.txt'), 'r', encoding="utf-8") as meta, \
      open(os.path.join(os.path.dirname(__file__), 'ui_about_.ui'), 'w') as filledUi:
     t = Template(about.read())
     for line in meta.readlines():


### PR DESCRIPTION
O aboutdialog.py estava capotando no meu computador (linha 32).
Dados: macOS Mojave (10.14.5), QGIS 3.4.7 e DSGTools branch qgis3.0_migration.