### PR TITLE
Dev bug duplicated param name

### DIFF
--- a/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
+++ b/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
@@ -409,7 +409,7 @@ class DsgToolsProcessingModel(QgsTask):
                     "errorMessage" : ""
                 }
                 for paramName, vl in self.runModel(self.feedback).items():
-                    baseName = paramName.split(":", 2)[-1]
+                    baseName = paramName.rsplit(":", 1)[-1]
                     name = baseName
                     idx = 1
                     while name in self.output["result"]:

--- a/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
+++ b/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
@@ -80,7 +80,6 @@ class DsgToolsProcessingModel(QgsTask):
         # self.setTitle(taskName or self.displayName())
         self.feedback = feedback or QgsProcessingFeedback()
         self.feedback.canceled.connect(self.cancel)
-        self.setOnFinished()
         self.output = {
             "result" : dict(),
             "status" : False,
@@ -436,24 +435,6 @@ class DsgToolsProcessingModel(QgsTask):
                 return True
         return False
 
-    def setOnFinished(self, callback=None):
-        """
-        Defines a callback to be activated once model is finished. This 
-        callable will be ADDED to the normal behaviour and is called from
-        'finished' metho, hence from the main thread.
-        :param callback: (callable) callable to be triggered.
-        """
-        if callback is None or not callable(callback):
-            self._callback = lambda: None
-        self._callback = callback
-
-    def onFinished(self, status):
-        """
-        Method that runs a callback associated with current model right after
-        it finishes its execution. Model's finishing status may be used.
-        """
-        self._callback()
-
     def finished(self, result):
         """
         Reimplemented from parent QgsTask. Method works a postprocessing one,
@@ -468,5 +449,4 @@ class DsgToolsProcessingModel(QgsTask):
             self.output["finishStatus"] = 'failed'
         else:
             self.output["finishStatus"] = 'finished'
-        self.onFinished(self.output["finishStatus"])
         self.modelFinished.emit(self)

--- a/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
+++ b/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
@@ -359,7 +359,7 @@ class QualityAssuranceWorkflow(QObject):
         def modelCompleted(model, step):
             self.output[model.name()] = model.output
             self._multiStepFeedback.setCurrentStep(step)
-            # self.handleFlags(model)
+            self.handleFlags(model)
         if firstModelName is not None:
             for idx, model in self._executionOrder.items():
                 if model.name() == firstModelName:
@@ -374,17 +374,16 @@ class QualityAssuranceWorkflow(QObject):
         for idx, currentModel in self._executionOrder.items():
             if idx < initialIdx:
                 continue
-            currentModel.begun.connect(
-                partial(self.modelStarted.emit, currentModel)
-            )
             # all models MUST pass through this postprocessing method
             currentModel.taskCompleted.connect(
                 partial(modelCompleted, currentModel, idx + 1)
             )
+            currentModel.begun.connect(
+                partial(self.modelStarted.emit, currentModel)
+            )
             currentModel.taskTerminated.connect(
                 partial(self.modelFailed.emit, currentModel)
             )
-            currentModel.setOnFinished(partial(self.handleFlags, currentModel))
             if idx != modelCount - 1:
                 self._executionOrder[idx + 1].addSubTask(
                     currentModel,

--- a/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
+++ b/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
@@ -21,7 +21,7 @@
 """
 
 import os, json
-from time import sleep
+from time import sleep, time
 from functools import partial
 
 from qgis.core import (QgsApplication,
@@ -255,14 +255,23 @@ class QualityAssuranceWorkflow(QObject):
         this method provides a 'static' execution alternative.
         :return: (dict) a map to each model's output.
         """
-        output = dict()
+        self.output = dict()
         for model in self.validModels().values():
+            start = time()
+            mName = model.name()
+            self.output[mName] = dict()
             try:
-                output[model.name()] = model.runModel()
+                self.output[mName]["result"] = {
+                    k.split(":", 2)[-1] : v \
+                        for k, v in model.runModel(model.feedback).items()
+                }
+                self.output[mName]["status"] = True
             except:
-                output[model.name()] = None
+                self.output[mName]["result"] = None
+                self.output[mName]["status"] = False
+            self.output[mName]["executionTime"] = time() - start
         self.finished()
-        return output
+        return self.output
 
     def setupModelTask(self, model):
         """
@@ -342,7 +351,7 @@ class QualityAssuranceWorkflow(QObject):
         :param cooldown: (float) time to wait till next model is started.
         """
         self._executionOrder = {
-            idx : model for idx, model in enumerate(self.validModels().values())
+            idx: model for idx, model in enumerate(self.validModels().values())
         }
         modelCount = len(self._executionOrder)
         if self.hasInvalidModel() or modelCount == 0:
@@ -350,7 +359,7 @@ class QualityAssuranceWorkflow(QObject):
         def modelCompleted(model, step):
             self.output[model.name()] = model.output
             self._multiStepFeedback.setCurrentStep(step)
-            self.handleFlags(model)
+            # self.handleFlags(model)
         if firstModelName is not None:
             for idx, model in self._executionOrder.items():
                 if model.name() == firstModelName:
@@ -365,13 +374,17 @@ class QualityAssuranceWorkflow(QObject):
         for idx, currentModel in self._executionOrder.items():
             if idx < initialIdx:
                 continue
+            currentModel.begun.connect(
+                partial(self.modelStarted.emit, currentModel)
+            )
             # all models MUST pass through this postprocessing method
             currentModel.taskCompleted.connect(
                 partial(modelCompleted, currentModel, idx + 1)
             )
-            currentModel.begun.connect(
-                partial(self.modelStarted.emit, currentModel)
+            currentModel.taskTerminated.connect(
+                partial(self.modelFailed.emit, currentModel)
             )
+            currentModel.setOnFinished(partial(self.handleFlags, currentModel))
             if idx != modelCount - 1:
                 self._executionOrder[idx + 1].addSubTask(
                     currentModel,


### PR DESCRIPTION
Enquanto produzindo as aulas, verificou-se que:

1. caso o nome de parâmetros de saída de modelos usados no worflow possuíssem mais de 1 caracter ':' em sua composição, não era bem identificado pelo workflow / model; e
2. parâmetros de saída que possuam o mesmo nome no model não são interpretados corretamente pelo workflow, ocasionando a não parada do workflow havendo flags em alguns casos.

Ambos consertados neste PR.