### PR TITLE
fixed #478

### DIFF
--- a/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
+++ b/gui/ProductionTools/Toolboxes/AttributeTools/code_list.py
@@ -205,6 +205,21 @@ class CodeList(QDockWidget, FORM_CLASS):
         self.blockAllSignals(False)
         self.resetFields()
 
+    def edgvVersion(self, db):
+        """
+        Identifies EDGV version from the database being handled.
+        :param db: (QSqlDatabase) database to be checked.
+        :return: (str) current EDGV version.
+        """
+        # this method is not supposed to be here and must be crossed out on
+        # future database abstraction refactor.  
+        sql = {
+            "QSQLITE": "SELECT edgvversion FROM public_db_metadata;",
+            "QPSQL": "SELECT edgvversion FROM public.db_metadata;"
+        }.pop(db.driverName(), "")
+        query = QSqlQuery(sql, db)
+        return query.value(0) if query.next() else ""
+
     def getAllEdgvDomainsFromTableName(self, table):
         """
         EDGV databases deployed by DSGTools have a set of domain tables. Gets the value map from such DB.
@@ -233,7 +248,7 @@ class CodeList(QDockWidget, FORM_CLASS):
                     db.setDatabaseName(uri.database())
                     db.setUserName(uri.username())
                     db.setPassword(uri.password())
-                    sql = 'select code, code_name from dominios.{field} order by code'   
+                    sql = 'select code, code_name from dominios.{field} order by code'
                 if not db.open():
                     db.close()
                     return ret
@@ -242,8 +257,13 @@ class CodeList(QDockWidget, FORM_CLASS):
                     if fieldName in self.specialEdgvAttributes():
                         # EDGV "special" attributes that are have different domains depending on 
                         # which class it belongs to
-                        category = (table if isinstance(table, str) else table.name()).split("_")[0]
-                        fieldN = "{attribute}_{cat}".format(attribute=fieldName, cat=category)
+                        if self.edgvVersion(db) in ("2.1.3 Pro", "3.0 Pro"):
+                            cat = table if isinstance(table, str) else table.name()
+                            # Pro versions now follow the logic "{attribute}_{CLASS_NAME}"
+                            cat = cat.rsplit("_", 1)[0].split("_", 1)[-1]
+                        else:
+                            cat = (table if isinstance(table, str) else table.name()).split("_")[0]
+                        fieldN = "{attribute}_{cat}".format(attribute=fieldName, cat=cat)
                         query = QSqlQuery(sql.format(field=fieldN), db)
                     else:
                         query = QSqlQuery(sql.format(field=fieldName), db)
@@ -264,7 +284,7 @@ class CodeList(QDockWidget, FORM_CLASS):
         depending on which category the EDGV class belongs to.
         :return: (list-of-str) list of "special" EDGV classes. 
         """
-        return ["finalidade", "relacionado", "coincidecomdentrode"]
+        return ["finalidade", "relacionado", "coincidecomdentrode", "tipo"]
 
     def getEdgvDomainsFromTableName(self, table, field=None):
         """
@@ -305,11 +325,11 @@ class CodeList(QDockWidget, FORM_CLASS):
                     return ret
                 query = QSqlQuery(sql, db)
                 if not query.isActive():
-                    return ret       
+                    return ret
                 while query.next():
                     code = str(query.value(0))
                     code_name = query.value(1)
-                    ret[code_name] = code      
+                    ret[code_name] = code
                 db.close()
             except:
                 pass


### PR DESCRIPTION
O atributo "tipo" é um dos que são considerados "especiais": mais de uma camada possui este atributo e possuem mapas de valores distintos para cada camada.

Além disso, a resolução de conflitos destes atributos no _schema_ de domínios foi mudada nas versões EDGV Pro. Nestes casos a tabela de domínio do atributo recebe o nome "[ATRIBUTO]\_[NOME\_CLASSE]", em choque ao que era antes: "[ATRIBUTO]\_[SIGLA\_CATEGORIA]".