### PR TITLE
Dev reclassify tool bugs refactor

### DIFF
--- a/core/GeometricTools/layerHandler.py
+++ b/core/GeometricTools/layerHandler.py
@@ -1588,3 +1588,20 @@ class LayerHandler(QObject):
                     )
                 }
         return classFieldMap
+
+    def getDefaultValues(self, layer):
+        """
+        Gets the default values for all fields as from the provider.
+        :param layer: (QgsVectorLayer) layer to have its default values read.
+        :return: (dict) a map from attribute name to its default value.
+        """
+        provider = layer.dataProvider()
+        fields = layer.fields()
+        defaultValues = dict()
+        for idx, f in enumerate(fields):
+            if fields.fieldOrigin(idx) == fields.OriginExpression:
+                # ignore virtual fields
+                continue
+            providerIdx = fields.fieldOriginIndex(idx)
+            defaultValues[f.name()] = provider.defaultValueClause(providerIdx)
+        return defaultValues

--- a/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
+++ b/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
@@ -36,11 +36,8 @@ from qgis.PyQt.QtWidgets import (QWidget,
                                  QComboBox,
                                  QPushButton,
                                  QHBoxLayout,
-                                 QFileDialog,
                                  QMessageBox,
-                                 QRadioButton,
-                                 QDoubleSpinBox,
-                                 QTableWidgetItem)
+                                 QDoubleSpinBox)
 
 from DsgTools.core.Utils.utils import Utils
 from DsgTools.core.GeometricTools.layerHandler import LayerHandler
@@ -355,12 +352,13 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
         for row in range(table.rowCount()):
             attr = table.cellWidget(row, self.ATTR_COL).text().replace("&", "")
             valueWidget = table.cellWidget(row, self.VAL_COL)
+            isPk = row in pkIdxList
             if not attrMap or attr not in attrMap:
                 attrMap[attr] = {
                     "value": None,
                     "editable": False,
-                    "ignored": False,
-                    "isPk": False
+                    "ignored": isPk, # default is False unless it's a PK attr
+                    "isPk": isPk
                 }
             {
                 QLineEdit: lambda v: valueWidget.setText(v or ""),
@@ -368,12 +366,13 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
                 QDoubleSpinBox: lambda v: valueWidget.setValue(v or 0.0),
                 QComboBox: lambda v: setMappedValue(valueWidget, attr, v)
             }[type(valueWidget)](attrMap[attr]["value"])
+            valueWidget.setEnabled(not attrMap[attr]["ignored"])
             table.cellWidget(row, self.EDIT_COL).cb.setChecked(
                 attrMap[attr]["editable"])
             table.cellWidget(row, self.IGNORED_COL).cb.setChecked(
                 attrMap[attr]["ignored"])
             table.setCellWidget(row, self.PK_COL,
-                self.pkWidget() if row in pkIdxList else QWidget())
+                self.pkWidget() if isPk else QWidget())
 
     def attributeMap(self):
         """
@@ -390,15 +389,13 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
             valueWidget = table.cellWidget(row, self.VAL_COL)
             attrMap[attr]["ignored"] = table.cellWidget(row, self.IGNORED_COL)\
                                             .cb.isChecked()
-            if attrMap[attr]["ignored"]:
-                attrMap[attr]["value"] = None
-            else:
-                attrMap[attr]["value"] = {
-                    QLineEdit: lambda: valueWidget.text(),
-                    QSpinBox: lambda: valueWidget.value(),
-                    QDoubleSpinBox: lambda: valueWidget.value(),
-                    QComboBox: lambda: vMaps[attr][valueWidget.currentText()]
-                }[type(valueWidget)]()
+            # "ignored" still allows the value to be set as last priority
+            attrMap[attr]["value"] = {
+                QLineEdit: lambda: valueWidget.text(),
+                QSpinBox: lambda: valueWidget.value(),
+                QDoubleSpinBox: lambda: valueWidget.value(),
+                QComboBox: lambda: vMaps[attr][valueWidget.currentText()]
+            }[type(valueWidget)]()
             attrMap[attr]["isPk"] = isinstance(
                 table.cellWidget(row, self.PK_COL), QPushButton)
             attrMap[attr]["editable"] = table.cellWidget(row, self.EDIT_COL)\
@@ -515,12 +512,16 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
         self.attributeTableWidget.setRowCount(0)
         fields = layer.fields() if layer else []
         pkIdxList = layer.primaryKeyAttributes() if layer else []
-        attrMap = self.button.attributeMap()
-        b = self.readButton()
+        if layer.name() == self.button.layer():
+            attrMap = self.button.attributeMap()
+        else:
+            # it does not make sense to use the saved map valued for a
+            # different layer selection
+            attrMap = dict()
         valueMaps = dict()
         # displayed values are always "aliased" when possible, so map needs to
         # be reversed (e.g. set to actual value to display name)
-        for fName, vMap in b.valueMaps().items():
+        for fName, vMap in self.readButton().valueMaps().items():
             valueMaps[fName] = {v: k for k, v in vMap.items()}
         virtualFields = list()
         for idx, f in enumerate(fields):
@@ -534,10 +535,18 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
             if fName in virtualFields:
                 # virtual fields are ignored
                 continue
+            isPk = row in pkIdxList
             notNull = not utils.fieldIsNullable(field)
             self.attributeTableWidget.setCellWidget(
                 row, self.ATTR_COL, self.attributeNameWidget(fName, notNull))
-            value = attrMap[fName]["value"] if fName in attrMap else None
+            if fName not in attrMap:
+                attrMap[fName] = {
+                    "value": None,
+                    "editable": False,
+                    "ignored": isPk, # default is False unless it's a PK attr
+                    "isPk": isPk
+                }
+            value = attrMap[fName]["value"]
             if fName in valueMaps:
                 vWidget = QComboBox()
                 vWidget.addItems(set(valueMaps[fName].values()))
@@ -546,14 +555,17 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
                     vWidget.setCurrentText(value)
             else:
                 vWidget = self.valueWidget(field, value)
+            vWidget.setEnabled(not attrMap[fName]["ignored"])
             self.attributeTableWidget.setCellWidget(row, self.VAL_COL, vWidget)
             ccbEdit = self.centeredCheckBox()
+            ccbEdit.cb.setChecked(attrMap[fName]["editable"])
             self.attributeTableWidget.setCellWidget(
                 row, self.EDIT_COL, ccbEdit)
-            ccbIgore = self.centeredCheckBox()
-            ccbIgore.cb.toggled.connect(partial(setDisabled, vWidget))
+            ccbIgnore = self.centeredCheckBox()
+            ccbIgnore.cb.setChecked(attrMap[fName]["ignored"])
+            ccbIgnore.cb.toggled.connect(partial(setDisabled, vWidget))
             self.attributeTableWidget.setCellWidget(
-                row, self.IGNORED_COL, ccbIgore)
+                row, self.IGNORED_COL, ccbIgnore)
             def checkExclusiveCB(ccb1, ccb2):
                 """
                 Method to make two CB to be mutually exclusive (like radio buttons.
@@ -567,12 +579,12 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
                     ccb1 = cb
                 if ccb1.cb.isChecked() and ccb2.cb.isChecked():
                     ccb2.cb.setChecked(False)
-            exclusiveCb = partial(checkExclusiveCB, ccbEdit, ccbIgore)
-            ccbIgore.cb.toggled.connect(exclusiveCb)
+            exclusiveCb = partial(checkExclusiveCB, ccbEdit, ccbIgnore)
+            ccbIgnore.cb.toggled.connect(exclusiveCb)
             ccbEdit.cb.toggled.connect(exclusiveCb)
             # since row is from an enum of fields, field idx = row
             self.attributeTableWidget.setCellWidget(row, self.PK_COL,
-                self.pkWidget() if row in pkIdxList else QWidget())
+                self.pkWidget() if isPk else QWidget())
 
     def setButton(self, button):
         """
@@ -652,7 +664,6 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
         self.keywordCheckBox.setEnabled(enabled)
         self.keywordLineEdit.setEnabled(enabled)
         self.shortcutCheckBox.setEnabled(enabled)
-        # self.shortcutWidget.setEnabled(enabled)
         self.openFormCheckBox.setEnabled(enabled)
         self.mMapLayerComboBox.setEnabled(enabled)
         self.attributeTableWidget.setEnabled(enabled)

--- a/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
+++ b/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
@@ -547,11 +547,29 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
             else:
                 vWidget = self.valueWidget(field, value)
             self.attributeTableWidget.setCellWidget(row, self.VAL_COL, vWidget)
+            ccbEdit = self.centeredCheckBox()
             self.attributeTableWidget.setCellWidget(
-                row, self.EDIT_COL, self.centeredCheckBox())
-            ccb = self.centeredCheckBox()
-            ccb.cb.toggled.connect(partial(setDisabled, vWidget))
-            self.attributeTableWidget.setCellWidget(row, self.IGNORED_COL, ccb)
+                row, self.EDIT_COL, ccbEdit)
+            ccbIgore = self.centeredCheckBox()
+            ccbIgore.cb.toggled.connect(partial(setDisabled, vWidget))
+            self.attributeTableWidget.setCellWidget(
+                row, self.IGNORED_COL, ccbIgore)
+            def checkExclusiveCB(ccb1, ccb2):
+                """
+                Method to make two CB to be mutually exclusive (like radio buttons.
+                """
+                cb = self.sender()
+                if cb == ccb2.cb:
+                    # just to make sure var 'cb1' is always the cb that was
+                    # checked by the user
+                    cb = ccb2
+                    ccb2 = ccb1
+                    ccb1 = cb
+                if ccb1.cb.isChecked() and ccb2.cb.isChecked():
+                    ccb2.cb.setChecked(False)
+            exclusiveCb = partial(checkExclusiveCB, ccbEdit, ccbIgore)
+            ccbIgore.cb.toggled.connect(exclusiveCb)
+            ccbEdit.cb.toggled.connect(exclusiveCb)
             # since row is from an enum of fields, field idx = row
             self.attributeTableWidget.setCellWidget(row, self.PK_COL,
                 self.pkWidget() if row in pkIdxList else QWidget())

--- a/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
+++ b/gui/CustomWidgets/BasicInterfaceWidgets/buttonPropWidget.py
@@ -522,11 +522,18 @@ class ButtonPropWidget(QWidget, FORM_CLASS):
         # be reversed (e.g. set to actual value to display name)
         for fName, vMap in b.valueMaps().items():
             valueMaps[fName] = {v: k for k, v in vMap.items()}
-        self.attributeTableWidget.setRowCount(len(fields))
+        virtualFields = list()
+        for idx, f in enumerate(fields):
+            if fields.fieldOrigin(idx) == fields.OriginExpression:
+                virtualFields.append(f.name())
+        self.attributeTableWidget.setRowCount(len(fields) - len(virtualFields))
         def setDisabled(w, status):
             w.setEnabled(not status)
         for row, field in enumerate(fields):
             fName = field.name()
+            if fName in virtualFields:
+                # virtual fields are ignored
+                continue
             notNull = not utils.fieldIsNullable(field)
             self.attributeTableWidget.setCellWidget(
                 row, self.ATTR_COL, self.attributeNameWidget(fName, notNull))

--- a/gui/CustomWidgets/BasicInterfaceWidgets/buttonSetupWidget.py
+++ b/gui/CustomWidgets/BasicInterfaceWidgets/buttonSetupWidget.py
@@ -71,7 +71,7 @@ class ButtonSetupWidget(QDialog, FORM_CLASS):
         # making the button selection to stand out a little bit
         if "Night Mapping" in app.activeThemePath():
             ss = """QHeaderView::section:checked
-                { color:gray; background-color:white; }"""
+                { color:black; background-color:white; }"""
         else:
             ss = """QHeaderView::section:checked
                 { color:gray; background-color:black; }"""

--- a/gui/CustomWidgets/BasicInterfaceWidgets/buttonSetupWidget.py
+++ b/gui/CustomWidgets/BasicInterfaceWidgets/buttonSetupWidget.py
@@ -23,7 +23,7 @@
 
 import os, json
 
-from qgis.core import Qgis, QgsMessageLog
+from qgis.core import Qgis, QgsMessageLog, QgsApplication
 from qgis.gui import QgsMessageBar
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (Qt,
@@ -44,6 +44,7 @@ from DsgTools.gui.ProductionTools.Toolboxes.CustomFeatureToolBox.customButtonSet
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'buttonSetupWidget.ui'))
+app = QgsApplication.instance()
 
 class ButtonSetupWidget(QDialog, FORM_CLASS):
     def __init__(self, parent=None, buttonSetup=None):
@@ -66,6 +67,15 @@ class ButtonSetupWidget(QDialog, FORM_CLASS):
         for w in ("savePushButton", "undoPushButton", "removePushButton",
                   "buttonPropWidget"):
             getattr(self, w).setEnabled(bEnabled)
+        
+        # making the button selection to stand out a little bit
+        if "Night Mapping" in app.activeThemePath():
+            ss = """QHeaderView::section:checked
+                { color:gray; background-color:white; }"""
+        else:
+            ss = """QHeaderView::section:checked
+                { color:gray; background-color:black; }"""
+        self.tableWidget.setStyleSheet(ss)
 
     def raiseWarning(self, msg, title=None, lvl=None, duration=None):
         """

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customButtonSetup.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customButtonSetup.py
@@ -826,8 +826,11 @@ class CustomFeatureButton(QObject):
                 vl = self.vectorLayer()
                 fields = vl.fields()
                 pkIdxList = vl.primaryKeyAttributes()
-                for field in fields:
+                for idx, field in enumerate(fields):
                     fieldName = field.name()
+                    if fields.fieldOrigin(idx) == fields.OriginExpression:
+                        # virtual fields are ignored
+                        continue
                     if fieldName not in attrMap:
                         self._props["attributeMap"][fieldName] = {
                             "value": None,

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
@@ -265,6 +265,7 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
         """
         self.tabWidget.blockSignals(True)
         self.tabWidget.clear()
+        self.tabWidget.blockSignals(False)
         self.setTabButtonsActive(0)
 
     def currentTab(self):

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
@@ -697,8 +697,7 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
         def updateFeatureWrapper():
             """
             A wrapper to make sure undo stack is set properly, avoiding crashes
-            upon undo-ing. It, however, breaks the "redo" - do not redo with
-            button on extraction mode active as it is a "add feature" process.
+            upon undoing and updates the stack to the modified feature command.
             """
             inLayer.endEditCommand()
             # remove original feature add command from undo stack
@@ -711,6 +710,7 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
             inLayer.featureAdded.connect(self._handleAddedFeature)
             inLayer.endEditCommand()
             self._timer.blockSignals(True)
+            self._timer.setParent(None)
             del self._timer
             self._timer = QTimer(self)
         self._timer.start(1)

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
@@ -137,6 +137,8 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
             if s is not None and s.isEnabled():
                 s.setEnabled(False)
         for l in QgsProject.instance().mapLayers().values():
+            if not isinstance(l, QgsVectorLayer):
+                continue
             try:
                 l.featureAdded.disconnect(self._handleAddedFeature)
             except TypeError:
@@ -444,6 +446,8 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
                 s.setEnabled(False)
         for l in QgsProject.instance().mapLayers().values():
             # make sure all layers are disconnected from handling method
+            if not isinstance(l, QgsVectorLayer):
+                continue
             try:
                 l.featureAdded.disconnect(self._handleAddedFeature)
             except TypeError:
@@ -740,6 +744,8 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
         Sets suppress form option to QGIS default for all layers on canvas.
         """
         for layer in QgsProject.instance().mapLayers().values():
+            if not isinstance(layer, QgsVectorLayer):
+                continue
             self.setSuppressFormOption(layer)
 
     def featuresToBeReclassified(self, b):

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
@@ -263,7 +263,9 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
         """
         Clears all tabs created for the buttons.
         """
+        self.tabWidget.blockSignals(True)
         self.tabWidget.clear()
+        self.setTabButtonsActive(0)
 
     def currentTab(self):
         """


### PR DESCRIPTION
Corrige alguns problemas:

- campos virtuais não estavam sendo ignorados na configuração de um botão;
- as opções "ignorado" e "editável" para os atributos foi definido como mutuamente excludente;
- erro ao tentar usar a ferramenta com camadas raster carregadas;
- modificada o estilo da tabela onde se define a ordem dos botões na configuração de perfis de botões ("_setups_");
- erro ao tentar editar um _setup_ em alguns cenários;
- campos não editáveis estavam habilitados no formulário de aquisição de feição; e
- QGIS encerrava bruscamente quando se adicionava feições com a opção de "abrir formulário" ativa.