### PR TITLE
Dev fix cft undo rem feat

### DIFF
--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customButtonSetup.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customButtonSetup.py
@@ -22,6 +22,7 @@
 """
 
 import os
+import copy
 import platform
 from string import Template
 from datetime import datetime
@@ -868,7 +869,7 @@ class CustomFeatureButton(QObject):
         creation.
         :return: (dict) attribute map for new/updated features.
         """
-        return dict(self._props["attributeMap"])
+        return copy.deepcopy(self._props["attributeMap"])
 
     def supportedTools(self):
         """

--- a/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
+++ b/gui/ProductionTools/Toolboxes/CustomFeatureToolBox/customFeatureTool.py
@@ -773,11 +773,12 @@ class CustomFeatureTool(QDockWidget, FORM_CLASS):
             # the tool's modification
             stack = inLayer.undoStack()
             cmd = stack.command(stack.count() - 1)
+            attrChanged = cmd.text() == 'Attributes changed'
             cmd.undo()
             cmd.setObsolete(True)
             stack.undo()
             if added:
-                if b.openForm():
+                if b.openForm() and attrChanged:
                     # if form was opened and confirmed, layer will have an
                     # 'Attributes changed' edit command stacked as well
                     stack.undo()


### PR DESCRIPTION
Ao adicionar uma feição que abre formulário de feição e não atualizar seus atributos, o comando anterior era desfeito (podendo remover feições).