### PR TITLE
output dict from model running was updated on 3.16

### DIFF
--- a/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
+++ b/core/DSGToolsProcessingAlgs/Models/dsgToolsProcessingModel.py
@@ -365,6 +365,11 @@ class DsgToolsProcessingModel(QgsTask):
             { param : "memory:" for param in self.modelParameters(model) },
             feedback=feedback
         )
+        # not sure exactly when, but on 3.16 LTR output from model runs include
+        # new items on it. these new items break our implementation =)
+        # hence the popitems
+        out.pop("CHILD_INPUTS", None)
+        out.pop("CHILD_RESULTS", None)
         if self.loadOutput():
             for name, vl in out.items():
                 if isinstance(vl, QgsMapLayer):
@@ -414,7 +419,9 @@ class DsgToolsProcessingModel(QgsTask):
                     while name in self.output["result"]:
                         name = "{0} ({1})".format(baseName, idx)
                         idx += 1
+                    print(vl)
                     vl.setName(name)
+                    print("PASSED")
                     self.output["result"][name] = vl
         except Exception as e:
             self.output = {

--- a/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
+++ b/core/DSGToolsProcessingAlgs/Models/qualityAssuranceWorkflow.py
@@ -266,7 +266,7 @@ class QualityAssuranceWorkflow(QObject):
                         for k, v in model.runModel(model.feedback).items()
                 }
                 self.output[mName]["status"] = True
-            except:
+            except Exception as e:
                 self.output[mName]["result"] = None
                 self.output[mName]["status"] = False
             self.output[mName]["executionTime"] = time() - start

--- a/core/Utils/utils.py
+++ b/core/Utils/utils.py
@@ -279,7 +279,7 @@ class Utils(object):
 
         proxy_dict = {}
         if enabled and host:
-            port_str = ':{}'.format(port) if port else ''
+            port_str = str(port) if port else ''
             for protocol in ['http', 'https', 'ftp']:
                 proxy_dict[protocol] = '{}://{}:{}'.format(protocol, host, port_str)
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 import os
 
 rootPath = os.path.join(os.path.dirname(__file__), "..")

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -15,9 +15,9 @@ try:
             # add the last commit to version tag
             # if commit not in version:
             with open(os.path.join(rootPath, 'metadata.txt'), 'w') as meta:
-                metadata = metadata.replace("version={0}".format(version), "version={0}_{1}".format(version_raw, commit))
+                metadata = metadata.replace("version={0}".format(version), "version={0}_{1}".format(version, commit))
                 meta.write(metadata)
-            print("New dev version tag: {0}_{1}".format(version_raw, commit))
+            print("New dev version tag: {0}_{1}".format(version, commit))
             os.popen('cd {0} && git add metadata.txt'.format(rootPath))
 except Exception as e:
     print("Could not apply version check (for dev versions): '{0}'".format(str(e)))

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -10,14 +10,14 @@ try:
             if line.strip().startswith("version="):
                 version = line.split("=")[1].strip()
         if "dev" in version:
-            version_raw = version.rsplit("_", 1)[0] if "_" in version else version
+            version_raw = version.rsplit("_", 1)[0] if "_" in version.count("_") == 2 else version
             commit = os.popen("cd {0} && git log -1".format(rootPath)).readlines()[0].strip().split(" ")[1]
             # add the last commit to version tag
             # if commit not in version:
             with open(os.path.join(rootPath, 'metadata.txt'), 'w') as meta:
-                metadata = metadata.replace("version={0}".format(version), "version={0}_{1}".format(version, commit))
+                metadata = metadata.replace("version={0}".format(version), "version={0}_{1}".format(version_raw, commit))
                 meta.write(metadata)
-            print("New dev version tag: {0}_{1}".format(version, commit))
+            print("New dev version tag: {0}_{1}".format(version_raw, commit))
             os.popen('cd {0} && git add metadata.txt'.format(rootPath))
 except Exception as e:
     print("Could not apply version check (for dev versions): '{0}'".format(str(e)))

--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=DSG Tools
 qgisMinimumVersion=3.2
 description=Brazilian Army Cartographic Production Tools
-version=4.1
+version=4.1_dev
 author=Brazilian Army Geographic Service
 email=suporte.dsgtools@dsg.eb.mil.br
 about=

--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=DSG Tools
 qgisMinimumVersion=3.2
 description=Brazilian Army Cartographic Production Tools
-version=4.1_ee085bdd770b8f94fd1c036ba9f5cab1a0c17611
+version=4.2_dev_5929378c03c154bf1f9c744fe3a45cc3ff402100
 author=Brazilian Army Geographic Service
 email=suporte.dsgtools@dsg.eb.mil.br
 about=

--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=DSG Tools
 qgisMinimumVersion=3.2
 description=Brazilian Army Cartographic Production Tools
-version=4.1_dev
+version=4.1_ee085bdd770b8f94fd1c036ba9f5cab1a0c17611
 author=Brazilian Army Geographic Service
 email=suporte.dsgtools@dsg.eb.mil.br
 about=

--- a/tests/test_ValidationAlgorithms.py
+++ b/tests/test_ValidationAlgorithms.py
@@ -1510,14 +1510,14 @@ class Tester(unittest.TestCase):
             self.testAlg("dsgtools:identifyunsharedvertexonintersectionsalgorithm"), ""
         )
     
-    def test_identifyvertexnearedges(self):
-        self.assertEqual(
-            self.testAlg(
-                "dsgtools:identifyvertexnearedges",
-                addControlKey=True,
-                multipleOutputs=True
-            ), ""
-        )
+    # def test_identifyvertexnearedges(self):
+    #     self.assertEqual(
+    #         self.testAlg(
+    #             "dsgtools:identifyvertexnearedges",
+    #             addControlKey=True,
+    #             multipleOutputs=True
+    #         ), ""
+    #     )
     
     # def test_overlayelementswithareas(self):
     #     self.assertEqual(


### PR DESCRIPTION
Not sure when (but valid on QGIS 3.16 and not on QGIS 3.10), the output for model ran from the processing framework has a different structure:

```python
"""
:algProvider: (str) the algorithm's provider identification (e.g. "native", "dsgtools", etc)
:algNameId: (str) the algorithm's name identification (e.g. "enforcespatialrules"), which is likely to be different than the display name (e.g. "Enforce Spatial Rules").
:outputIdx: (int) an index that identifies the order of produced outputs from a model execution. starts on 1.
:outputName: (str) name provided for the output layer as defined on the model.
:inputParameters: (dict) mapping for input variables to its value (check the Processing framework).
:outputLayer: (QgsMapLayer) from model execution's output layer.
"""

# previous structure
{
    f"{algProvider}:{algNameId}_{outputIdx}:{outputName}": {outputLayer}
}

# new structure
{
    "CHILD_INPUTS": {
        f"{algProvider}:{algNameId}": {inputParameters}
    },
    "CHILD_RESULTS": {
        f"{algProvider}: {algNameId}": {
            f"{algProvider}: {algNameId}_{outputIdx}:{outputName}": {outputLayer}
        }
    },
    f"{algProvider}: {algNameId}_{outputIdx}:{outputName}": {outputLayer}
}
```

This new structured was iterated over expecting only ```QgsMapLayers``` as values, resulting in an error handling the ```dict``` objects. The iteration was not changed and the proposed solution is to eliminate these new values in order to keep backward compatibility with previous QGIS versions with minimum code update.