### PR TITLE
Dev #537

### DIFF
--- a/core/DbModels/DomainMapping/edgv_213.json
+++ b/core/DbModels/DomainMapping/edgv_213.json
@@ -1,0 +1,4988 @@
+{
+    "cb_adm_area_pub_civil_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_adm_area_pub_militar_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_adm_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_adm_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_adm_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_adm_edif_pub_civil_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcivil": [
+            "tipoedifcivil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipousoedif",
+            "code"
+        ]
+    },
+    "cb_adm_edif_pub_civil_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcivil": [
+            "tipoedifcivil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipousoedif",
+            "code"
+        ]
+    },
+    "cb_adm_edif_pub_militar_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifmil": [
+            "tipoedifmil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipousoedif",
+            "code"
+        ]
+    },
+    "cb_adm_edif_pub_militar_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifmil": [
+            "tipoedifmil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipousoedif",
+            "code"
+        ]
+    },
+    "cb_adm_posto_fiscal_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopostofisc": [
+            "tipopostofisc",
+            "code"
+        ]
+    },
+    "cb_adm_posto_fiscal_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopostofisc": [
+            "tipopostofisc",
+            "code"
+        ]
+    },
+    "cb_adm_posto_pol_rod_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopostopol": [
+            "tipopostopol",
+            "code"
+        ]
+    },
+    "cb_adm_posto_pol_rod_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopostopol": [
+            "tipopostopol",
+            "code"
+        ]
+    },
+    "cb_asb_area_abast_agua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_asb_area_saneamento_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_asb_cemiterio_a": {
+        "denominacaoassociada": [
+            "denominacaoassociada",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipocemiterio": [
+            "tipocemiterio",
+            "code"
+        ]
+    },
+    "cb_asb_cemiterio_p": {
+        "denominacaoassociada": [
+            "denominacaoassociada",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipocemiterio": [
+            "tipocemiterio",
+            "code"
+        ]
+    },
+    "cb_asb_dep_abast_agua_a": {
+        "construcao": [
+            "construcao",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_asb",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaoagua": [
+            "situacaoagua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodepabast": [
+            "tipodepabast",
+            "code"
+        ]
+    },
+    "cb_asb_dep_abast_agua_p": {
+        "construcao": [
+            "construcao",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_asb",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaoagua": [
+            "situacaoagua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodepabast": [
+            "tipodepabast",
+            "code"
+        ]
+    },
+    "cb_asb_dep_saneamento_a": {
+        "construcao": [
+            "construcao",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_asb",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "residuo": [
+            "residuo",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodepsaneam": [
+            "tipodepsaneam",
+            "code"
+        ],
+        "tiporesiduo": [
+            "tiporesiduo",
+            "code"
+        ]
+    },
+    "cb_asb_dep_saneamento_p": {
+        "construcao": [
+            "construcao",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_asb",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "residuo": [
+            "residuo",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodepsaneam": [
+            "tipodepsaneam",
+            "code"
+        ],
+        "tiporesiduo": [
+            "tiporesiduo",
+            "code"
+        ]
+    },
+    "cb_asb_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_asb_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_asb_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_asb_edif_abast_agua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifabast": [
+            "tipoedifabast",
+            "code"
+        ]
+    },
+    "cb_asb_edif_abast_agua_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifabast": [
+            "tipoedifabast",
+            "code"
+        ]
+    },
+    "cb_asb_edif_saneamento_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifsaneam": [
+            "tipoedifsaneam",
+            "code"
+        ]
+    },
+    "cb_asb_edif_saneamento_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifsaneam": [
+            "tipoedifsaneam",
+            "code"
+        ]
+    },
+    "cb_eco_area_agrop_ext_veg_pesca_a": {
+        "destinadoa": [
+            "destinadoa",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_eco_area_comerc_serv_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_eco_area_ext_mineral_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_eco_area_industrial_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_eco_deposito_geral_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipoconteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipodepgeral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipoexposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipoprodutoresiduo",
+            "code"
+        ],
+        "tratamento": [
+            "tratamento",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidadevolume",
+            "code"
+        ]
+    },
+    "cb_eco_deposito_geral_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipoconteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipodepgeral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipoexposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipoprodutoresiduo",
+            "code"
+        ],
+        "tratamento": [
+            "tratamento",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidadevolume",
+            "code"
+        ]
+    },
+    "cb_eco_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_eco_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_eco_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_eco_edif_agrop_ext_veg_pesca_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifagropec": [
+            "tipoedifagropec",
+            "code"
+        ]
+    },
+    "cb_eco_edif_agrop_ext_veg_pesca_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifagropec": [
+            "tipoedifagropec",
+            "code"
+        ]
+    },
+    "cb_eco_edif_comerc_serv_a": {
+        "finalidade": [
+            "finalidade_eco",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipoedifcomercserv",
+            "code"
+        ]
+    },
+    "cb_eco_edif_comerc_serv_p": {
+        "finalidade": [
+            "finalidade_eco",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipoedifcomercserv",
+            "code"
+        ]
+    },
+    "cb_eco_edif_ext_mineral_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodivisaocnae": [
+            "tipodivisaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_edif_ext_mineral_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodivisaocnae": [
+            "tipodivisaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_edif_industrial_a": {
+        "chamine": [
+            "chamine",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodivisaocnae": [
+            "tipodivisaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_edif_industrial_p": {
+        "chamine": [
+            "chamine",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipodivisaocnae": [
+            "tipodivisaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_equip_agropec_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipoequipagropec",
+            "code"
+        ]
+    },
+    "cb_eco_equip_agropec_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipoequipagropec",
+            "code"
+        ]
+    },
+    "cb_eco_equip_agropec_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipoequipagropec",
+            "code"
+        ]
+    },
+    "cb_eco_ext_mineral_a": {
+        "atividade": [
+            "atividade",
+            "code"
+        ],
+        "formaextracao": [
+            "formaextracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "procextracao": [
+            "procextracao",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoextmin": [
+            "tipoextmin",
+            "code"
+        ],
+        "tipopocomina": [
+            "tipopocomina",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipoprodutoresiduo",
+            "code"
+        ],
+        "tiposecaocnae": [
+            "tiposecaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_ext_mineral_p": {
+        "atividade": [
+            "atividade",
+            "code"
+        ],
+        "formaextracao": [
+            "formaextracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "procextracao": [
+            "procextracao",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoextmin": [
+            "tipoextmin",
+            "code"
+        ],
+        "tipopocomina": [
+            "tipopocomina",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipoprodutoresiduo",
+            "code"
+        ],
+        "tiposecaocnae": [
+            "tiposecaocnae",
+            "code"
+        ]
+    },
+    "cb_eco_plataforma_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoplataforma": [
+            "tipoplataforma",
+            "code"
+        ]
+    },
+    "cb_eco_plataforma_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoplataforma": [
+            "tipoplataforma",
+            "code"
+        ]
+    },
+    "cb_edu_area_ensino_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_edu_area_lazer_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_edu_area_religiosa_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_edu_area_ruinas_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_edu_arquibancada_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_edu_arquibancada_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_edu_campo_quadra_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocampoquadra": [
+            "tipocampoquadra",
+            "code"
+        ]
+    },
+    "cb_edu_campo_quadra_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocampoquadra": [
+            "tipocampoquadra",
+            "code"
+        ]
+    },
+    "cb_edu_coreto_tribuna_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_edu_coreto_tribuna_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_edu_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_edu_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_edu_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_edu_edif_const_lazer_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoediflazer": [
+            "tipoediflazer",
+            "code"
+        ]
+    },
+    "cb_edu_edif_const_lazer_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoediflazer": [
+            "tipoediflazer",
+            "code"
+        ]
+    },
+    "cb_edu_edif_const_turistica_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "ovgd": [
+            "ovgd",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifturist": [
+            "tipoedifturist",
+            "code"
+        ]
+    },
+    "cb_edu_edif_const_turistica_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "ovgd": [
+            "ovgd",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifturist": [
+            "tipoedifturist",
+            "code"
+        ]
+    },
+    "cb_edu_edif_ensino_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_edu_edif_ensino_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_edu_edif_religiosa_a": {
+        "ensino": [
+            "ensino",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifrelig": [
+            "tipoedifrelig",
+            "code"
+        ]
+    },
+    "cb_edu_edif_religiosa_p": {
+        "ensino": [
+            "ensino",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifrelig": [
+            "tipoedifrelig",
+            "code"
+        ]
+    },
+    "cb_edu_piscina_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_edu_pista_competicao_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipopista",
+            "code"
+        ]
+    },
+    "cb_edu_ruina_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_edu_ruina_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_enc_antena_comunic_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "posicaoreledific": [
+            "posicaoreledific",
+            "code"
+        ]
+    },
+    "cb_enc_area_comunicacao_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_enc_area_energia_eletrica_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_enc_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_enc_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_enc_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_enc_edif_comunic_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modalidade": [
+            "modalidade",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcomunic": [
+            "tipoedifcomunic",
+            "code"
+        ]
+    },
+    "cb_enc_edif_comunic_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modalidade": [
+            "modalidade",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifcomunic": [
+            "tipoedifcomunic",
+            "code"
+        ]
+    },
+    "cb_enc_edif_energia_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifenergia": [
+            "tipoedifenergia",
+            "code"
+        ]
+    },
+    "cb_enc_edif_energia_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifenergia": [
+            "tipoedifenergia",
+            "code"
+        ]
+    },
+    "cb_enc_est_gerad_energia_eletr_a": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipoestgerad",
+            "code"
+        ]
+    },
+    "cb_enc_est_gerad_energia_eletr_l": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipoestgerad",
+            "code"
+        ]
+    },
+    "cb_enc_est_gerad_energia_eletr_p": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipoestgerad",
+            "code"
+        ]
+    },
+    "cb_enc_grupo_transformadores_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_enc_grupo_transformadores_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_enc_hidreletrica_a": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_enc_hidreletrica_l": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_enc_hidreletrica_p": {
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_enc_ponto_trecho_energia_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoptoenergia": [
+            "tipoptoenergia",
+            "code"
+        ]
+    },
+    "cb_enc_termeletrica_a": {
+        "combrenovavel": [
+            "combrenovavel",
+            "code"
+        ],
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "geracao": [
+            "geracao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocombustivel": [
+            "tipocombustivel",
+            "code"
+        ],
+        "tipomaqtermica": [
+            "tipomaqtermica",
+            "code"
+        ]
+    },
+    "cb_enc_termeletrica_p": {
+        "combrenovavel": [
+            "combrenovavel",
+            "code"
+        ],
+        "destenergelet": [
+            "destenergelet",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "geracao": [
+            "geracao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocombustivel": [
+            "tipocombustivel",
+            "code"
+        ],
+        "tipomaqtermica": [
+            "tipomaqtermica",
+            "code"
+        ]
+    },
+    "cb_enc_torre_comunic_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "ovgd": [
+            "ovgd",
+            "code"
+        ],
+        "posicaoreledific": [
+            "posicaoreledific",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_enc_torre_energia_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "ovgd": [
+            "ovgd",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotorre": [
+            "tipotorre",
+            "code"
+        ]
+    },
+    "cb_enc_trecho_comunic_l": {
+        "emduto": [
+            "emduto",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicaorelativa",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotrechocomunic": [
+            "tipotrechocomunic",
+            "code"
+        ]
+    },
+    "cb_enc_trecho_energia_l": {
+        "emduto": [
+            "emduto",
+            "code"
+        ],
+        "especie": [
+            "especie",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicaorelativa",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_enc_zona_linhas_energia_com_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_area_umida_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoareaumida": [
+            "tipoareaumida",
+            "code"
+        ]
+    },
+    "cb_hid_bacia_hidrografica_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_banco_areia_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ],
+        "tipobanco": [
+            "tipobanco",
+            "code"
+        ]
+    },
+    "cb_hid_banco_areia_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ],
+        "tipobanco": [
+            "tipobanco",
+            "code"
+        ]
+    },
+    "cb_hid_barragem_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "usoprincipal",
+            "code"
+        ]
+    },
+    "cb_hid_barragem_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "usoprincipal",
+            "code"
+        ]
+    },
+    "cb_hid_barragem_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "usoprincipal",
+            "code"
+        ]
+    },
+    "cb_hid_comporta_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_hid_comporta_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_hid_confluencia_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_corredeira_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_corredeira_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_corredeira_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_hid_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_hid_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_hid_fonte_dagua_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "qualidagua": [
+            "qualidagua",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "tipofontedagua": [
+            "tipofontedagua",
+            "code"
+        ]
+    },
+    "cb_hid_foz_maritima_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_foz_maritima_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_foz_maritima_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_ilha_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoilha": [
+            "tipoilha",
+            "code"
+        ]
+    },
+    "cb_hid_ilha_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoilha": [
+            "tipoilha",
+            "code"
+        ]
+    },
+    "cb_hid_ilha_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoilha": [
+            "tipoilha",
+            "code"
+        ]
+    },
+    "cb_hid_limite_massa_dagua_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ],
+        "tipolimmassa": [
+            "tipolimmassa",
+            "code"
+        ]
+    },
+    "cb_hid_massa_dagua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "salinidade": [
+            "salinidade",
+            "code"
+        ],
+        "tipomassadagua": [
+            "tipomassadagua",
+            "code"
+        ]
+    },
+    "cb_hid_natureza_fundo_a": {
+        "espessalgas": [
+            "espessalgas",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ]
+    },
+    "cb_hid_natureza_fundo_l": {
+        "espessalgas": [
+            "espessalgas",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ]
+    },
+    "cb_hid_natureza_fundo_p": {
+        "espessalgas": [
+            "espessalgas",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materialpredominante": [
+            "materialpredominante",
+            "code"
+        ]
+    },
+    "cb_hid_ponto_drenagem_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "relacionado": [
+            "relacionado_hid",
+            "code"
+        ]
+    },
+    "cb_hid_ponto_inicio_drenagem_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "nascente": [
+            "nascente",
+            "code"
+        ]
+    },
+    "cb_hid_quebramar_molhe_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "situamare": [
+            "situamare",
+            "code"
+        ],
+        "tipoquebramolhe": [
+            "tipoquebramolhe",
+            "code"
+        ]
+    },
+    "cb_hid_quebramar_molhe_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "situamare": [
+            "situamare",
+            "code"
+        ],
+        "tipoquebramolhe": [
+            "tipoquebramolhe",
+            "code"
+        ]
+    },
+    "cb_hid_queda_dagua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoqueda": [
+            "tipoqueda",
+            "code"
+        ]
+    },
+    "cb_hid_queda_dagua_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoqueda": [
+            "tipoqueda",
+            "code"
+        ]
+    },
+    "cb_hid_queda_dagua_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoqueda": [
+            "tipoqueda",
+            "code"
+        ]
+    },
+    "cb_hid_recife_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaocosta": [
+            "situacaocosta",
+            "code"
+        ],
+        "situamare": [
+            "situamare",
+            "code"
+        ],
+        "tiporecife": [
+            "tiporecife",
+            "code"
+        ]
+    },
+    "cb_hid_recife_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaocosta": [
+            "situacaocosta",
+            "code"
+        ],
+        "situamare": [
+            "situamare",
+            "code"
+        ],
+        "tiporecife": [
+            "tiporecife",
+            "code"
+        ]
+    },
+    "cb_hid_recife_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaocosta": [
+            "situacaocosta",
+            "code"
+        ],
+        "situamare": [
+            "situamare",
+            "code"
+        ],
+        "tiporecife": [
+            "tiporecife",
+            "code"
+        ]
+    },
+    "cb_hid_reservatorio_hidrico_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "usoprincipal": [
+            "usoprincipal",
+            "code"
+        ]
+    },
+    "cb_hid_rocha_em_agua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ]
+    },
+    "cb_hid_rocha_em_agua_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ]
+    },
+    "cb_hid_sumidouro_vertedouro_p": {
+        "causa": [
+            "causa",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tiposumvert": [
+            "tiposumvert",
+            "code"
+        ]
+    },
+    "cb_hid_terreno_suj_inundacao_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_hid_trecho_drenagem_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_hid",
+            "code"
+        ],
+        "compartilhado": [
+            "compartilhado",
+            "code"
+        ],
+        "dentrodepoligono": [
+            "dentrodepoligono",
+            "code"
+        ],
+        "eixoprincipal": [
+            "eixoprincipal",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "navegabilidade": [
+            "navegabilidade",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ]
+    },
+    "cb_hid_trecho_massa_dagua_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "salinidade": [
+            "salinidade",
+            "code"
+        ],
+        "tipotrechomassa": [
+            "tipotrechomassa",
+            "code"
+        ]
+    },
+    "cb_lim_area_de_litigio_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_area_de_propriedade_particular_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_area_desenv_controle_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_area_desenv_controle_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_area_uso_comunitario_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoareausocomun": [
+            "tipoareausocomun",
+            "code"
+        ]
+    },
+    "cb_lim_area_uso_comunitario_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoareausocomun": [
+            "tipoareausocomun",
+            "code"
+        ]
+    },
+    "cb_lim_bairro_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_delimitacao_fisica_l": {
+        "eletrificada": [
+            "eletrificada",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "tipodelimfis": [
+            "tipodelimfis",
+            "code"
+        ]
+    },
+    "cb_lim_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_lim_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_lim_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_lim_distrito_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_limite_area_especial_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolimareaesp": [
+            "tipolimareaesp",
+            "code"
+        ]
+    },
+    "cb_lim_limite_intra_munic_adm_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolimintramun": [
+            "tipolimintramun",
+            "code"
+        ]
+    },
+    "cb_lim_limite_operacional_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolimoper": [
+            "tipolimoper",
+            "code"
+        ]
+    },
+    "cb_lim_limite_particular_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_limite_politico_adm_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolimpol": [
+            "tipolimpol",
+            "code"
+        ]
+    },
+    "cb_lim_linha_de_limite_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_marco_de_limite_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "referencialaltim": [
+            "referencialaltim",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistemageodesico",
+            "code"
+        ],
+        "tipomarcolim": [
+            "tipomarcolim",
+            "code"
+        ]
+    },
+    "cb_lim_municipio_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_outras_unid_protegidas_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipooutunidprot": [
+            "tipooutunidprot",
+            "code"
+        ]
+    },
+    "cb_lim_outras_unid_protegidas_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipooutunidprot": [
+            "tipooutunidprot",
+            "code"
+        ]
+    },
+    "cb_lim_outros_limites_oficiais_l": {
+        "coincidecomdentrode": [
+            "coincidecomdentrode_lim",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipooutlimofic": [
+            "tipooutlimofic",
+            "code"
+        ]
+    },
+    "cb_lim_pais_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_regiao_administrativa_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_sub_distrito_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_terra_indigena_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaojuridica": [
+            "situacaojuridica",
+            "code"
+        ]
+    },
+    "cb_lim_terra_indigena_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaojuridica": [
+            "situacaojuridica",
+            "code"
+        ]
+    },
+    "cb_lim_terra_publica_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_terra_publica_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_conserv_nao_snuc_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_conserv_nao_snuc_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_federacao_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_protecao_integral_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipounidprotinteg": [
+            "tipounidprotinteg",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_protecao_integral_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipounidprotinteg": [
+            "tipounidprotinteg",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_uso_sustentavel_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipounidusosust": [
+            "tipounidusosust",
+            "code"
+        ]
+    },
+    "cb_lim_unidade_uso_sustentavel_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipounidusosust": [
+            "tipounidusosust",
+            "code"
+        ]
+    },
+    "cb_loc_aglom_rural_de_ext_urbana_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_loc_aglomerado_rural_isolado_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoaglomrurisol": [
+            "tipoaglomrurisol",
+            "code"
+        ]
+    },
+    "cb_loc_area_edificada_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_loc_area_habitacional_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_loc_area_urbana_isolada_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoassociado": [
+            "tipoassociado",
+            "code"
+        ]
+    },
+    "cb_loc_capital_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipocapital": [
+            "tipocapital",
+            "code"
+        ]
+    },
+    "cb_loc_cidade_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_loc_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_loc_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_loc_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_loc_edif_habitacional_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_loc_edif_habitacional_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_loc_edificacao_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_loc_edificacao_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_loc_hab_indigena_a": {
+        "coletiva": [
+            "coletiva",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "isolada": [
+            "isolada",
+            "code"
+        ]
+    },
+    "cb_loc_hab_indigena_p": {
+        "coletiva": [
+            "coletiva",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "isolada": [
+            "isolada",
+            "code"
+        ]
+    },
+    "cb_loc_nome_local_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_loc_vila_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_pto_area_est_med_fenom_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_pto_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_pto_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_pto_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_pto_edif_constr_est_med_fen_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_pto_edif_constr_est_med_fen_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_pto_pto_controle_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "materializado": [
+            "materializado",
+            "code"
+        ],
+        "referencialaltim": [
+            "referencialaltim",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistemageodesico",
+            "code"
+        ],
+        "tipoptocontrole": [
+            "tipoptocontrole",
+            "code"
+        ],
+        "tiporef": [
+            "tiporef",
+            "code"
+        ]
+    },
+    "cb_pto_pto_est_med_fenomenos_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoptoestmed": [
+            "tipoptoestmed",
+            "code"
+        ]
+    },
+    "cb_pto_pto_ref_geod_topo_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "proximidade": [
+            "proximidade",
+            "code"
+        ],
+        "rede": [
+            "rede",
+            "code"
+        ],
+        "referencialaltim": [
+            "referencialaltim",
+            "code"
+        ],
+        "referencialgrav": [
+            "referencialgrav",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistemageodesico",
+            "code"
+        ],
+        "situacaomarco": [
+            "situacaomarco",
+            "code"
+        ],
+        "tipoptorefgeodtopo": [
+            "tipoptorefgeodtopo",
+            "code"
+        ],
+        "tiporef": [
+            "tiporef",
+            "code"
+        ]
+    },
+    "cb_rel_alter_fisiog_antropica_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipoalterantrop",
+            "code"
+        ]
+    },
+    "cb_rel_alter_fisiog_antropica_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipoalterantrop",
+            "code"
+        ]
+    },
+    "cb_rel_curva_nivel_l": {
+        "depressao": [
+            "depressao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "indice": [
+            "indice",
+            "code"
+        ]
+    },
+    "cb_rel_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_rel_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_rel_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_rel_dolina_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_dolina_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_duna_a": {
+        "fixa": [
+            "fixa",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_duna_p": {
+        "fixa": [
+            "fixa",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_elemento_fisiog_natural_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipoelemnat",
+            "code"
+        ]
+    },
+    "cb_rel_elemento_fisiog_natural_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipoelemnat",
+            "code"
+        ]
+    },
+    "cb_rel_elemento_fisiog_natural_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipoelemnat",
+            "code"
+        ]
+    },
+    "cb_rel_gruta_caverna_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipogrutacaverna": [
+            "tipogrutacaverna",
+            "code"
+        ]
+    },
+    "cb_rel_pico_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_ponto_cotado_altimetrico_p": {
+        "cotacomprovada": [
+            "cotacomprovada",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_rel_rocha_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tiporocha": [
+            "tiporocha",
+            "code"
+        ]
+    },
+    "cb_rel_rocha_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tiporocha": [
+            "tiporocha",
+            "code"
+        ]
+    },
+    "cb_rel_terreno_exposto_a": {
+        "causaexposicao": [
+            "causaexposicao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoterrexp": [
+            "tipoterrexp",
+            "code"
+        ]
+    },
+    "cb_sau_area_saude_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_sau_area_servico_social_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_sau_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_sau_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_sau_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_sau_edif_saude_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "nivelatencao": [
+            "nivelatencao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_sau_edif_saude_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "nivelatencao": [
+            "nivelatencao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_sau_edif_servico_social_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_sau_edif_servico_social_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoclassecnae": [
+            "tipoclassecnae",
+            "code"
+        ]
+    },
+    "cb_tra_area_duto_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_area_estrut_transporte_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_arruamento_l": {
+        "canteirodivisorio": [
+            "canteirodivisorio",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "cb_tra_atracadouro_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipoatracad",
+            "code"
+        ]
+    },
+    "cb_tra_atracadouro_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipoatracad",
+            "code"
+        ]
+    },
+    "cb_tra_atracadouro_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipoatracad",
+            "code"
+        ]
+    },
+    "cb_tra_caminho_aereo_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocaminhoaereo": [
+            "tipocaminhoaereo",
+            "code"
+        ],
+        "tipousocaminhoaer": [
+            "tipousocaminhoaer",
+            "code"
+        ]
+    },
+    "cb_tra_ciclovia_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "cb_tra_condutor_hidrico_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "mattransp": [
+            "mattransp",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicaorelativa",
+            "code"
+        ],
+        "setor": [
+            "setor",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacaoespacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipocondutor": [
+            "tipocondutor",
+            "code"
+        ]
+    },
+    "cb_tra_cremalheira_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_cremalheira_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_tra_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_tra_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_tra_eclusa_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_eclusa_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_eclusa_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_edif_constr_aeroportuaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifaero": [
+            "tipoedifaero",
+            "code"
+        ]
+    },
+    "cb_tra_edif_constr_aeroportuaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifaero": [
+            "tipoedifaero",
+            "code"
+        ]
+    },
+    "cb_tra_edif_constr_portuaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifport": [
+            "tipoedifport",
+            "code"
+        ]
+    },
+    "cb_tra_edif_constr_portuaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifport": [
+            "tipoedifport",
+            "code"
+        ]
+    },
+    "cb_tra_edif_metro_ferroviaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "funcaoedifmetroferrov": [
+            "funcaoedifmetroferrov",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "multimodal": [
+            "multimodal",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_edif_metro_ferroviaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "funcaoedifmetroferrov": [
+            "funcaoedifmetroferrov",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "multimodal": [
+            "multimodal",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_edif_rodoviaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifrod": [
+            "tipoedifrod",
+            "code"
+        ]
+    },
+    "cb_tra_edif_rodoviaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoedifrod": [
+            "tipoedifrod",
+            "code"
+        ]
+    },
+    "cb_tra_entroncamento_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipoentroncamento": [
+            "tipoentroncamento",
+            "code"
+        ]
+    },
+    "cb_tra_faixa_seguranca_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_fundeadouro_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "destinacaofundeadouro": [
+            "destinacaofundeadouro",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_fundeadouro_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "destinacaofundeadouro": [
+            "destinacaofundeadouro",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_fundeadouro_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "destinacaofundeadouro": [
+            "destinacaofundeadouro",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_funicular_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_funicular_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_galeria_bueiro_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_galeria_bueiro_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_girador_ferroviario_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_local_critico_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolocalcrit": [
+            "tipolocalcrit",
+            "code"
+        ]
+    },
+    "cb_tra_local_critico_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolocalcrit": [
+            "tipolocalcrit",
+            "code"
+        ]
+    },
+    "cb_tra_local_critico_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipolocalcrit": [
+            "tipolocalcrit",
+            "code"
+        ]
+    },
+    "cb_tra_obstaculo_navegacao_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipoobst",
+            "code"
+        ]
+    },
+    "cb_tra_obstaculo_navegacao_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipoobst",
+            "code"
+        ]
+    },
+    "cb_tra_obstaculo_navegacao_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacaoemagua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipoobst",
+            "code"
+        ]
+    },
+    "cb_tra_passag_elevada_viaduto_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopassagviad": [
+            "tipopassagviad",
+            "code"
+        ]
+    },
+    "cb_tra_passag_elevada_viaduto_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopassagviad": [
+            "tipopassagviad",
+            "code"
+        ]
+    },
+    "cb_tra_passagem_nivel_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_patio_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_patio_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_pista_ponto_pouso_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "homologacao": [
+            "homologacao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipopista",
+            "code"
+        ],
+        "usopista": [
+            "usopista",
+            "code"
+        ]
+    },
+    "cb_tra_pista_ponto_pouso_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "homologacao": [
+            "homologacao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipopista",
+            "code"
+        ],
+        "usopista": [
+            "usopista",
+            "code"
+        ]
+    },
+    "cb_tra_pista_ponto_pouso_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "homologacao": [
+            "homologacao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipopista",
+            "code"
+        ],
+        "usopista": [
+            "usopista",
+            "code"
+        ]
+    },
+    "cb_tra_ponte_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoponte": [
+            "tipoponte",
+            "code"
+        ]
+    },
+    "cb_tra_ponte_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipoponte": [
+            "tipoponte",
+            "code"
+        ]
+    },
+    "cb_tra_ponto_duto_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "relacionado": [
+            "relacionado_dut",
+            "code"
+        ]
+    },
+    "cb_tra_ponto_hidroviario_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "relacionado": [
+            "relacionado_hdr",
+            "code"
+        ]
+    },
+    "cb_tra_ponto_rodoviario_ferrov_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "relacionado": [
+            "relacionado_fer_rod",
+            "code"
+        ]
+    },
+    "cb_tra_posto_combustivel_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_posto_combustivel_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_sinalizacao_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tiposinal": [
+            "tiposinal",
+            "code"
+        ]
+    },
+    "cb_tra_travessia_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipotravessia": [
+            "tipotravessia",
+            "code"
+        ]
+    },
+    "cb_tra_travessia_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipotravessia": [
+            "tipotravessia",
+            "code"
+        ]
+    },
+    "cb_tra_travessia_pedestre_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotravessiaped": [
+            "tipotravessiaped",
+            "code"
+        ]
+    },
+    "cb_tra_travessia_pedestre_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotravessiaped": [
+            "tipotravessiaped",
+            "code"
+        ]
+    },
+    "cb_tra_trecho_duto_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "mattransp": [
+            "mattransp",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicaorelativa",
+            "code"
+        ],
+        "setor": [
+            "setor",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacaoespacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotrechoduto": [
+            "tipotrechoduto",
+            "code"
+        ]
+    },
+    "cb_tra_trecho_ferroviario_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "bitola": [
+            "bitola",
+            "code"
+        ],
+        "eletrificada": [
+            "eletrificada",
+            "code"
+        ],
+        "emarruamento": [
+            "emarruamento",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "nrlinhas": [
+            "nrlinhas",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicaorelativa",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotrechoferrov": [
+            "tipotrechoferrov",
+            "code"
+        ]
+    },
+    "cb_tra_trecho_hidroviario_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ]
+    },
+    "cb_tra_trecho_rodoviario_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteirodivisorio": [
+            "canteirodivisorio",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotrechorod": [
+            "tipotrechorod",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "cb_tra_trilha_picada_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_tra_tunel_l": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotunel": [
+            "tipotunel",
+            "code"
+        ]
+    },
+    "cb_tra_tunel_p": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "matconstr": [
+            "matconstr",
+            "code"
+        ],
+        "modaluso": [
+            "modaluso",
+            "code"
+        ],
+        "operacional": [
+            "operacional",
+            "code"
+        ],
+        "posicaopista": [
+            "posicaopista",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacaofisica",
+            "code"
+        ],
+        "tipotunel": [
+            "tipotunel",
+            "code"
+        ]
+    },
+    "cb_veg_brejo_pantano_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipobrejopantano": [
+            "tipobrejopantano",
+            "code"
+        ]
+    },
+    "cb_veg_caatinga_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_campinarana_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_campo_a": {
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "ocorrenciaem": [
+            "ocorrenciaem",
+            "code"
+        ],
+        "tipocampo": [
+            "tipocampo",
+            "code"
+        ]
+    },
+    "cb_veg_cerrado_cerradao_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipocerr": [
+            "tipocerr",
+            "code"
+        ]
+    },
+    "cb_veg_descontinuidade_geometrica_a": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_veg_descontinuidade_geometrica_l": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_veg_descontinuidade_geometrica_p": {
+        "motivodescontinuidade": [
+            "motivodescontinuidade",
+            "code"
+        ]
+    },
+    "cb_veg_estepe_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_floresta_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "caracteristicafloresta": [
+            "caracteristicafloresta",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "especiepredominante": [
+            "especiepredominante",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_macega_chavascal_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "tipomacchav": [
+            "tipomacchav",
+            "code"
+        ]
+    },
+    "cb_veg_mangue_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_veg_area_contato_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    },
+    "cb_veg_veg_cultivada_a": {
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "cultivopredominante": [
+            "cultivopredominante",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_veg",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ],
+        "terreno": [
+            "terreno",
+            "code"
+        ],
+        "tipolavoura": [
+            "tipolavoura",
+            "code"
+        ]
+    },
+    "cb_veg_veg_restinga_a": {
+        "antropizada": [
+            "antropizada",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacaoporte",
+            "code"
+        ],
+        "denso": [
+            "denso",
+            "code"
+        ],
+        "geometriaaproximada": [
+            "geometriaaproximada",
+            "code"
+        ]
+    }
+}

--- a/core/DbModels/DomainMapping/edgv_213_pro.json
+++ b/core/DbModels/DomainMapping/edgv_213_pro.json
@@ -1,0 +1,1420 @@
+{
+    "edgv_aquisicao_centroide_hidrografia_p": {
+        "tipo": [
+            "tipo_hid",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aquisicao_centroide_vegetacao_p": {
+        "tipo": [
+            "tipo_veg",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aquisicao_limite_hidrografia_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aquisicao_limite_vegetacao_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_insumo_externo_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_insumo_externo_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_insumo_externo_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_moldura_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_moldura_area_continua_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_objeto_desconhecido_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_objeto_desconhecido_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_objeto_desconhecido_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_rascunho_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_aux_rascunho_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_cobter_area_edificada_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_cobter_corpo_dagua_a": {
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "tipo": [
+            "tipo_corpo_dagua",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_cobter_vegetacao_a": {
+        "tipo": [
+            "tipo_veg",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_constr_deposito_a": {
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_deposito",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_exposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "tipo_produto_residuo": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_constr_deposito_p": {
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_deposito",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_exposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "tipo_produto_residuo": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_constr_edificacao_a": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "tipo": [
+            "tipo_edificacao",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_constr_edificacao_p": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "tipo": [
+            "tipo_edificacao",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_constr_extracao_mineral_a": {
+        "forma_extracao": [
+            "forma_extracao",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_extracao_mineral",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "tipo_produto_residuo": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_constr_extracao_mineral_p": {
+        "forma_extracao": [
+            "forma_extracao",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_extracao_mineral",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "tipo_produto_residuo": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_constr_ocupacao_solo_a": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_ocupacao_solo",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_constr_ocupacao_solo_l": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_ocupacao_solo",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_constr_ocupacao_solo_p": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_ocupacao_solo",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_curva_nivel_l": {
+        "depressao": [
+            "booleano",
+            "code"
+        ],
+        "indice": [
+            "indice",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_fisiografico_a": {
+        "tipo": [
+            "tipo_elemento_fisiografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_fisiografico_l": {
+        "tipo": [
+            "tipo_elemento_fisiografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_fisiografico_p": {
+        "tipo": [
+            "tipo_elemento_fisiografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_hidrografico_a": {
+        "tipo": [
+            "tipo_elemento_hidrografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_hidrografico_l": {
+        "tipo": [
+            "tipo_elemento_hidrografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_elemento_hidrografico_p": {
+        "tipo": [
+            "tipo_elemento_hidrografico",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_ponto_cotado_p": {
+        "cota_comprovada": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_elemnat_trecho_drenagem_l": {
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "tipo": [
+            "tipo_trecho_drenagem",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_infraestrutura_a": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "posicao_relativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_infraestrutura",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_infraestrutura_l": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "posicao_relativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_infraestrutura",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_infraestrutura_p": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "posicao_relativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_infraestrutura",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_transportes_a": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_transportes",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_transportes_l": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_transportes",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_transportes_p": {
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_transportes",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_viario_l": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "modal_uso": [
+            "modal_uso",
+            "code"
+        ],
+        "posicao_pista": [
+            "posicao_pista",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_viario",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_elemento_viario_p": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "modal_uso": [
+            "modal_uso",
+            "code"
+        ],
+        "posicao_pista": [
+            "posicao_pista",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_elemento_viario",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_ferrovia_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "em_arruamento": [
+            "booleano",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "nr_linhas": [
+            "nr_linhas",
+            "code"
+        ],
+        "posicao_relativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_ferrovia",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_infra_pista_pouso_a": {
+        "homologacao": [
+            "booleano_estendido",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_pista_pouso",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "uso_pista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_infra_pista_pouso_l": {
+        "homologacao": [
+            "booleano_estendido",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_pista_pouso",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "uso_pista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_infra_pista_pouso_p": {
+        "homologacao": [
+            "booleano_estendido",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_pista_pouso",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "uso_pista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_infra_via_deslocamento_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteiro_divisorio": [
+            "canteiro_divisorio",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacao_fisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipo": [
+            "tipo_via_deslocamento",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "edgv_llp_delimitacao_fisica_l": {
+        "material_construcao": [
+            "material_construcao",
+            "code"
+        ],
+        "tipo": [
+            "tipo_delimitacao_fisica",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_limite_especial_a": {
+        "geometria_aproximada": [
+            "booleano",
+            "code"
+        ],
+        "tipo": [
+            "tipo_limite_especial",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_delimitacao": [
+            "tipo_linha_limites",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_limite_especial_l": {
+        "geometria_aproximada": [
+            "booleano",
+            "code"
+        ],
+        "tipo": [
+            "tipo_limite_especial",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_delimitacao": [
+            "tipo_linha_limites",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_limite_legal_a": {
+        "geometria_aproximada": [
+            "booleano",
+            "code"
+        ],
+        "tipo": [
+            "tipo_limite_legal",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_delimitacao": [
+            "tipo_linha_limites",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_limite_legal_l": {
+        "geometria_aproximada": [
+            "booleano",
+            "code"
+        ],
+        "tipo": [
+            "tipo_limite_legal",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_delimitacao": [
+            "tipo_linha_limites",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_localidade_p": {
+        "tipo": [
+            "tipo_localidade",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_llp_ponto_controle_p": {
+        "referencial_altim": [
+            "referencial_altim",
+            "code"
+        ],
+        "referencial_grav": [
+            "referencial_grav",
+            "code"
+        ],
+        "sistema_geodesico": [
+            "sistema_geodesico",
+            "code"
+        ],
+        "situacao_marco": [
+            "situacao_marco",
+            "code"
+        ],
+        "tipo": [
+            "tipo_pto",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ],
+        "tipo_ref": [
+            "tipo_ref",
+            "code"
+        ]
+    },
+    "edgv_rev_edificacao_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_edificacao_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_edificacao_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_hidrografia_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_hidrografia_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_hidrografia_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_reambulacao_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_reambulacao_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_reambulacao_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_revisao_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_revisao_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_revisao_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_transportes_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_transportes_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_transportes_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_vegetacao_a": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_vegetacao_l": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_rev_vegetacao_p": {
+        "corrigido": [
+            "booleano",
+            "code"
+        ],
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_edificacao_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_edificacao_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_edificacao_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_hidrografia_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_hidrografia_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_hidrografia_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_transportes_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_transportes_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_transportes_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_vegetacao_a": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_vegetacao_l": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    },
+    "edgv_val_vegetacao_p": {
+        "tipo_comprovacao": [
+            "tipo_comprovacao",
+            "code"
+        ],
+        "tipo_insumo": [
+            "tipo_insumo",
+            "code"
+        ]
+    }
+}

--- a/core/DbModels/DomainMapping/edgv_3.json
+++ b/core/DbModels/DomainMapping/edgv_3.json
@@ -1,0 +1,6384 @@
+{
+    "edgv_aer_pista_ponto_pouso_a": {
+        "homologacao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipo_pista",
+            "code"
+        ],
+        "usopista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_aer_pista_ponto_pouso_l": {
+        "homologacao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipo_pista",
+            "code"
+        ],
+        "usopista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_aer_pista_ponto_pouso_p": {
+        "homologacao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopista": [
+            "tipo_pista",
+            "code"
+        ],
+        "usopista": [
+            "uso_pista",
+            "code"
+        ]
+    },
+    "edgv_cbge_area_agropec_ext_vegetal_pesca_a": {
+        "destinadoa": [
+            "destinado_a",
+            "code"
+        ],
+        "tipoarea": [
+            "tipo_area",
+            "code"
+        ]
+    },
+    "edgv_cbge_area_de_propriedade_particular_a": {
+        "tipoarea": [
+            "tipo_area",
+            "code"
+        ]
+    },
+    "edgv_cbge_area_duto_a": {
+        "areavalvulas": [
+            "auxiliar",
+            "code"
+        ],
+        "bombeamento": [
+            "auxiliar",
+            "code"
+        ],
+        "tipoarea": [
+            "tipo_area",
+            "code"
+        ]
+    },
+    "edgv_cbge_area_habitacional_a": {
+        "tipoarea": [
+            "tipo_area",
+            "code"
+        ]
+    },
+    "edgv_cbge_area_uso_especifico_a": {
+        "tipoarea": [
+            "tipo_area",
+            "code"
+        ]
+    },
+    "edgv_cbge_canteiro_central_a": {
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ]
+    },
+    "edgv_cbge_canteiro_central_l": {
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ]
+    },
+    "edgv_cbge_cemiterio_a": {
+        "denominacaoassociada": [
+            "denominacao_associada",
+            "code"
+        ],
+        "destinacaocemiterio": [
+            "destinacao_cemiterio",
+            "code"
+        ],
+        "tipocemiterio": [
+            "tipo_cemiterio",
+            "code"
+        ]
+    },
+    "edgv_cbge_cemiterio_p": {
+        "denominacaoassociada": [
+            "denominacao_associada",
+            "code"
+        ],
+        "destinacaocemiterio": [
+            "destinacao_cemiterio",
+            "code"
+        ],
+        "tipocemiterio": [
+            "tipo_cemiterio",
+            "code"
+        ]
+    },
+    "edgv_cbge_delimitacao_fisica_l": {
+        "eletrificada": [
+            "auxiliar",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipodelimfis": [
+            "tipo_delim_fis",
+            "code"
+        ]
+    },
+    "edgv_cbge_deposito_geral_a": {
+        "estadofisico": [
+            "estado_fisico",
+            "code"
+        ],
+        "finalidadedep": [
+            "finalidade_deposito",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipo_conteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipo_dep_geral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipo_produto_residuo",
+            "code"
+        ],
+        "tratamento": [
+            "auxiliar",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidade_volume",
+            "code"
+        ]
+    },
+    "edgv_cbge_deposito_geral_p": {
+        "estadofisico": [
+            "estado_fisico",
+            "code"
+        ],
+        "finalidadedep": [
+            "finalidade_deposito",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipo_conteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipo_dep_geral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipo_produto_residuo",
+            "code"
+        ],
+        "tratamento": [
+            "auxiliar",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidade_volume",
+            "code"
+        ]
+    },
+    "edgv_cbge_entroncamento_area_a": {
+        "tipoentroncamento": [
+            "tipo_entroncamento",
+            "code"
+        ]
+    },
+    "edgv_cbge_estacionamento_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "finalidadepatio": [
+            "finalidade_patio",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "publico": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_cbge_passeio_a": {
+        "calcada": [
+            "auxiliar",
+            "code"
+        ],
+        "pavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ]
+    },
+    "edgv_cbge_passeio_l": {
+        "calcada": [
+            "auxiliar",
+            "code"
+        ],
+        "pavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ]
+    },
+    "edgv_cbge_poste_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoposte": [
+            "tipo_poste",
+            "code"
+        ]
+    },
+    "edgv_cbge_praca_a": {
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_cbge_trecho_arruamento_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteirodivisorio": [
+            "auxiliar",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "meiofio": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "sarjeta": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipovia": [
+            "tipo_via",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "edgv_cbge_trecho_arruamento_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteirodivisorio": [
+            "auxiliar",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "meiofio": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "sarjeta": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipovia": [
+            "tipo_via",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ]
+    },
+    "edgv_dut_galeria_bueiro_l": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "mattransp": [
+            "mat_transp",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "setor": [
+            "setor",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotrechoduto": [
+            "tipo_trecho_duto",
+            "code"
+        ]
+    },
+    "edgv_dut_galeria_bueiro_p": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "mattransp": [
+            "mat_transp",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "setor": [
+            "setor",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotrechoduto": [
+            "tipo_trecho_duto",
+            "code"
+        ]
+    },
+    "edgv_dut_trecho_duto_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "mattransp": [
+            "mat_transp",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "setor": [
+            "setor",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotrechoduto": [
+            "tipo_trecho_duto",
+            "code"
+        ]
+    },
+    "edgv_eco_equip_agropec_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipo_equip_agropec",
+            "code"
+        ]
+    },
+    "edgv_eco_equip_agropec_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipo_equip_agropec",
+            "code"
+        ]
+    },
+    "edgv_eco_equip_agropec_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoequipagropec": [
+            "tipo_equip_agropec",
+            "code"
+        ]
+    },
+    "edgv_eco_ext_mineral_a": {
+        "atividade": [
+            "atividade",
+            "code"
+        ],
+        "formaextracao": [
+            "forma_extracao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "procextracao": [
+            "proc_extracao",
+            "code"
+        ],
+        "secaoativecon": [
+            "secao_ativ_econ",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "tipoextmin": [
+            "tipo_ext_min",
+            "code"
+        ],
+        "tipopocomina": [
+            "tipo_poco_mina",
+            "code"
+        ],
+        "tipoproduto": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_eco_ext_mineral_p": {
+        "atividade": [
+            "atividade",
+            "code"
+        ],
+        "formaextracao": [
+            "forma_extracao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "procextracao": [
+            "proc_extracao",
+            "code"
+        ],
+        "secaoativecon": [
+            "secao_ativ_econ",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "tipoextmin": [
+            "tipo_ext_min",
+            "code"
+        ],
+        "tipopocomina": [
+            "tipo_poco_mina",
+            "code"
+        ],
+        "tipoproduto": [
+            "tipo_produto_residuo",
+            "code"
+        ]
+    },
+    "edgv_eco_plataforma_a": {
+        "tipoplataforma": [
+            "tipo_plataforma",
+            "code"
+        ]
+    },
+    "edgv_eco_plataforma_p": {
+        "tipoplataforma": [
+            "tipo_plataforma",
+            "code"
+        ]
+    },
+    "edgv_edf_banheiro_publico_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_banheiro_publico_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_abast_agua_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifabast": [
+            "tipo_edif_abast",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_abast_agua_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifabast": [
+            "tipo_edif_abast",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_agropec_ext_vegetal_pesca_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifagropec": [
+            "tipo_edif_agropec",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_agropec_ext_vegetal_pesca_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifagropec": [
+            "tipo_edif_agropec",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_comerc_serv_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipo_edif_comerc_serv",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_comerc_serv_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipo_edif_comerc_serv",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_comunic_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modalidade": [
+            "modalidade",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomunic": [
+            "tipo_edif_comunic",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_comunic_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modalidade": [
+            "modalidade",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomunic": [
+            "tipo_edif_comunic",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_aeroportuaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifaero": [
+            "tipo_edif_aero",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_aeroportuaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifaero": [
+            "tipo_edif_aero",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_est_med_fen_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_est_med_fen_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_lazer_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoediflazer": [
+            "tipo_edif_lazer",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_lazer_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoediflazer": [
+            "tipo_edif_lazer",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_portuaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifport": [
+            "tipo_edif_port",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_portuaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifport": [
+            "tipo_edif_port",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_turistica_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "ovgd": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifturist": [
+            "tipo_edif_turist",
+            "code"
+        ],
+        "tombada": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_constr_turistica_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "ovgd": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifturist": [
+            "tipo_edif_turist",
+            "code"
+        ],
+        "tombada": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_desenv_social_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "localizacaoequipdesenvsocial": [
+            "local_equip_desenv_social",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoequipdesenvsocial": [
+            "tipo_equip_desenv_social",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_desenv_social_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "localizacaoequipdesenvsocial": [
+            "local_equip_desenv_social",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoequipdesenvsocial": [
+            "tipo_equip_desenv_social",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_energia_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifenergia": [
+            "tipo_edif_energia",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_energia_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifenergia": [
+            "tipo_edif_energia",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_ensino_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_ensino_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_ext_mineral_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_ext_mineral_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_industrial_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "chamine": [
+            "auxiliar",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_industrial_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "chamine": [
+            "auxiliar",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_metro_ferroviaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifmetroferrov": [
+            "tipo_edif_metro_ferrov",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_metro_ferroviaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifmetroferrov": [
+            "tipo_edif_metro_ferrov",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_policia_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_policia_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_pub_civil_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_pub_civil_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_pub_militar_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoinstalmilitar": [
+            "tipo_instal_militar",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_pub_militar_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoinstalmilitar": [
+            "tipo_instal_militar",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_religiosa_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "crista": [
+            "auxiliar",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "ensino": [
+            "auxiliar",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifrelig": [
+            "tipo_edif_relig",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_religiosa_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "crista": [
+            "auxiliar",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "ensino": [
+            "auxiliar",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifrelig": [
+            "tipo_edif_relig",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_residencial_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_residencial_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_rodoviaria_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifrod": [
+            "tipo_edif_rod",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_rodoviaria_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifrod": [
+            "tipo_edif_rod",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_saneamento_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifsaneam": [
+            "tipo_edif_saneam",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_saneamento_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifsaneam": [
+            "tipo_edif_saneam",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_saude_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "nivelatencao": [
+            "nivel_atencao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edif_saude_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "nivelatencao": [
+            "nivel_atencao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edificacao_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_edificacao_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_hab_indigena_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "coletiva": [
+            "auxiliar",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "isolada": [
+            "auxiliar",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_hab_indigena_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "coletiva": [
+            "auxiliar",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "isolada": [
+            "auxiliar",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_combustivel_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipo_edif_comerc_serv",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_combustivel_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifcomercserv": [
+            "tipo_edif_comerc_serv",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_fiscal_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipopostofisc": [
+            "tipo_posto_fisc",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_fiscal_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipopostofisc": [
+            "tipo_posto_fisc",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_guarda_municipal_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_guarda_municipal_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_policia_militar_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoinstalmilitar": [
+            "tipo_instal_militar",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_policia_militar_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoinstalmilitar": [
+            "tipo_instal_militar",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_policia_rod_federal_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_posto_policia_rod_federal_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoedifpubcivil": [
+            "tipo_org_civil",
+            "code"
+        ],
+        "tipousoedif": [
+            "tipo_uso_edif",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_representacao_diplomatica_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tiporepdiplomatica": [
+            "tipo_rep_diplomatica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_edf_representacao_diplomatica_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "divisaoativecon": [
+            "divisao_ativ_econ",
+            "code"
+        ],
+        "grupoativecon": [
+            "grupo_ativ_econ",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "proprioadm": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tiporepdiplomatica": [
+            "tipo_rep_diplomatica",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_emu_acesso_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_acesso_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_acesso_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_ciclovia_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_elevador_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoelevador": [
+            "tipo_elevador",
+            "code"
+        ]
+    },
+    "edgv_emu_elevador_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoelevador": [
+            "tipo_elevador",
+            "code"
+        ]
+    },
+    "edgv_emu_elevador_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoelevador": [
+            "tipo_elevador",
+            "code"
+        ]
+    },
+    "edgv_emu_escadaria_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_escadaria_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_escadaria_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_poste_sinalizacao_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoposte": [
+            "tipo_poste",
+            "code"
+        ]
+    },
+    "edgv_emu_rampa_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_rampa_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_emu_rampa_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_enc_antena_comunic_p": {
+        "posicaoreledific": [
+            "posicao_rel_edific",
+            "code"
+        ]
+    },
+    "edgv_enc_central_geradora_eolica_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_central_geradora_eolica_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_est_gerad_energia_eletrica_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_est_gerad_energia_eletrica_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_hidreletrica_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoahe": [
+            "tipo_ahe",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_hidreletrica_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoahe": [
+            "tipo_ahe",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_hidreletrica_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoahe": [
+            "tipo_ahe",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_subest_transm_distrib_energia_eletrica_a": {
+        "centrodecarga": [
+            "auxiliar",
+            "code"
+        ],
+        "classeativecon": [
+            "classe_ativ_econ",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_enc_termeletrica_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipocombustivel": [
+            "tipo_combustivel",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_termeletrica_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipocombustivel": [
+            "tipo_combustivel",
+            "code"
+        ],
+        "tipoestgerad": [
+            "tipo_est_gerad",
+            "code"
+        ]
+    },
+    "edgv_enc_torre_comunic_p": {
+        "modalidade": [
+            "modalidade",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "ovgd": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaoreledific": [
+            "posicao_rel_edific",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_enc_torre_energia_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "ovgd": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_enc_trecho_comunic_l": {
+        "emduto": [
+            "auxiliar",
+            "code"
+        ],
+        "matcondutor": [
+            "mat_condutor",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotrechocomunic": [
+            "tipo_trecho_comunic",
+            "code"
+        ]
+    },
+    "edgv_enc_trecho_energia_l": {
+        "especie": [
+            "especie_trecho_energia",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "sin": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_fer_cremalheira_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_fer_cremalheira_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_fer_girador_ferroviario_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_fer_trecho_ferroviario_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "bitola": [
+            "bitola",
+            "code"
+        ],
+        "eletrificada": [
+            "auxiliar",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "nrlinhas": [
+            "nr_linhas",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaorelativa": [
+            "posicao_relativa",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotrechoferrov": [
+            "tipo_trecho_ferrov",
+            "code"
+        ]
+    },
+    "edgv_hdv_atracadouro_terminal_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "aptidaooperacional": [
+            "aptidao_operacional_atracadouro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipo_atracad",
+            "code"
+        ]
+    },
+    "edgv_hdv_atracadouro_terminal_l": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "aptidaooperacional": [
+            "aptidao_operacional_atracadouro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipo_atracad",
+            "code"
+        ]
+    },
+    "edgv_hdv_atracadouro_terminal_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "aptidaooperacional": [
+            "aptidao_operacional_atracadouro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoatracad": [
+            "tipo_atracad",
+            "code"
+        ]
+    },
+    "edgv_hdv_eclusa_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hdv_eclusa_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hdv_eclusa_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hdv_fundeadouro_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "tipofundeadouro": [
+            "tipo_fundeadouro",
+            "code"
+        ]
+    },
+    "edgv_hdv_fundeadouro_p": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "tipofundeadouro": [
+            "tipo_fundeadouro",
+            "code"
+        ]
+    },
+    "edgv_hdv_obstaculo_navegacao_a": {
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipo_obst",
+            "code"
+        ]
+    },
+    "edgv_hdv_obstaculo_navegacao_l": {
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipo_obst",
+            "code"
+        ]
+    },
+    "edgv_hdv_obstaculo_navegacao_p": {
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipoobst": [
+            "tipo_obst",
+            "code"
+        ]
+    },
+    "edgv_hdv_sinalizacao_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tiposinal": [
+            "tipo_sinal",
+            "code"
+        ]
+    },
+    "edgv_hdv_trecho_hidroviario_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hid_area_umida_a": {
+        "tipoareaumida": [
+            "tipo_area_umida",
+            "code"
+        ]
+    },
+    "edgv_hid_banco_areia_a": {
+        "materialpredominante": [
+            "material_predominante",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipobanco": [
+            "tipo_banco",
+            "code"
+        ]
+    },
+    "edgv_hid_barragem_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_barragem_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_barragem_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_canal_a": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_canal_l": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_comporta_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hid_comporta_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_hid_dique_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ]
+    },
+    "edgv_hid_dique_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ]
+    },
+    "edgv_hid_dique_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ]
+    },
+    "edgv_hid_fonte_dagua_p": {
+        "qualidagua": [
+            "qualid_agua",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "tipofontedagua": [
+            "tipo_fonte_dagua",
+            "code"
+        ]
+    },
+    "edgv_hid_ilha_a": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ],
+        "tipoilha": [
+            "tipo_ilha",
+            "code"
+        ]
+    },
+    "edgv_hid_ilha_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ],
+        "tipoilha": [
+            "tipo_ilha",
+            "code"
+        ]
+    },
+    "edgv_hid_massa_dagua_a": {
+        "artificial": [
+            "auxiliar",
+            "code"
+        ],
+        "dominialidade": [
+            "jurisdicao",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "salgada": [
+            "auxiliar",
+            "code"
+        ],
+        "tipomassadagua": [
+            "tipo_massa_dagua",
+            "code"
+        ]
+    },
+    "edgv_hid_quebramar_molhe_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoquebramolhe": [
+            "tipo_quebra_molhe",
+            "code"
+        ]
+    },
+    "edgv_hid_quebramar_molhe_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoquebramolhe": [
+            "tipo_quebra_molhe",
+            "code"
+        ]
+    },
+    "edgv_hid_queda_dagua_l": {
+        "tipoqueda": [
+            "tipo_queda",
+            "code"
+        ]
+    },
+    "edgv_hid_queda_dagua_p": {
+        "tipoqueda": [
+            "tipo_queda",
+            "code"
+        ]
+    },
+    "edgv_hid_recife_a": {
+        "situacaocosta": [
+            "situacao_costa",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tiporecife": [
+            "tipo_recife",
+            "code"
+        ]
+    },
+    "edgv_hid_recife_p": {
+        "situacaocosta": [
+            "situacao_costa",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tiporecife": [
+            "tipo_recife",
+            "code"
+        ]
+    },
+    "edgv_hid_rocha_em_agua_a": {
+        "formarocha": [
+            "forma_rocha",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_hid_rocha_em_agua_p": {
+        "formarocha": [
+            "forma_rocha",
+            "code"
+        ],
+        "situacaoemagua": [
+            "situacao_em_agua",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_hid_sumidouro_vertedouro_p": {
+        "causa": [
+            "causa",
+            "code"
+        ],
+        "tiposumvert": [
+            "tipo_sum_vert",
+            "code"
+        ]
+    },
+    "edgv_hid_trecho_drenagem_l": {
+        "navegavel": [
+            "auxiliar",
+            "code"
+        ],
+        "regime": [
+            "regime",
+            "code"
+        ],
+        "tipotrechodrenagem": [
+            "tipo_trecho_drenagem",
+            "code"
+        ]
+    },
+    "edgv_hid_vala_a": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_hid_vala_l": {
+        "finalidade": [
+            "finalidade_galeria_bueiro",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ],
+        "usoprincipal": [
+            "uso_principal",
+            "code"
+        ]
+    },
+    "edgv_laz_arquibancada_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_laz_campo_quadra_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipocampoquadra": [
+            "tipo_campo_quadra",
+            "code"
+        ]
+    },
+    "edgv_laz_campo_quadra_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipocampoquadra": [
+            "tipo_campo_quadra",
+            "code"
+        ]
+    },
+    "edgv_laz_piscina_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_laz_pista_competicao_a": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopistacomp": [
+            "tipo_pista_comp",
+            "code"
+        ]
+    },
+    "edgv_laz_pista_competicao_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopistacomp": [
+            "tipo_pista_comp",
+            "code"
+        ]
+    },
+    "edgv_laz_pista_competicao_p": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopistacomp": [
+            "tipo_pista_comp",
+            "code"
+        ]
+    },
+    "edgv_laz_ruina_a": {
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_laz_ruina_p": {
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_laz_sitio_arqueologico_a": {
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_laz_sitio_arqueologico_p": {
+        "cultura": [
+            "auxiliar",
+            "code"
+        ],
+        "turistica": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_lml_area_pub_militar_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ]
+    },
+    "edgv_lml_area_urbana_isolada_a": {
+        "tipoassociado": [
+            "tipo_associado",
+            "code"
+        ]
+    },
+    "edgv_lml_posic_geo_localidade_p": {
+        "tipolocalidade": [
+            "tipo_localidade",
+            "code"
+        ]
+    },
+    "edgv_lml_terra_indigena_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "situacaojuridica": [
+            "situacao_juridica",
+            "code"
+        ]
+    },
+    "edgv_lml_terra_publica_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ]
+    },
+    "edgv_lml_unidade_conservacao_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "tipounidprotegida": [
+            "tipo_unid_protegida",
+            "code"
+        ]
+    },
+    "edgv_lml_unidade_federacao_a": {
+        "sigla": [
+            "sigla_uf",
+            "code"
+        ]
+    },
+    "edgv_lml_unidade_protecao_integral_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "tipounidprotegida": [
+            "tipo_unid_protegida",
+            "code"
+        ],
+        "tipounidprotinteg": [
+            "tipo_unid_prot_integ",
+            "code"
+        ]
+    },
+    "edgv_lml_unidade_uso_sustentavel_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "tipounidprotegida": [
+            "tipo_unid_protegida",
+            "code"
+        ],
+        "tipounidusosust": [
+            "tipo_unid_uso_sust",
+            "code"
+        ]
+    },
+    "edgv_pto_marco_de_limite_p": {
+        "referencialaltim": [
+            "referencial_altim",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistema_geodesico",
+            "code"
+        ],
+        "tipomarcolim": [
+            "tipo_hierarquia",
+            "code"
+        ]
+    },
+    "edgv_pto_pto_est_med_fenomenos_p": {
+        "tipoptoestmed": [
+            "tipo_pto_est_med",
+            "code"
+        ]
+    },
+    "edgv_pto_pto_geod_topo_controle_p": {
+        "referencialaltim": [
+            "referencial_altim",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistema_geodesico",
+            "code"
+        ],
+        "tiporef": [
+            "tipo_ref",
+            "code"
+        ]
+    },
+    "edgv_pto_pto_ref_geod_topo_p": {
+        "proximidade": [
+            "proximidade",
+            "code"
+        ],
+        "redereferencia": [
+            "rede_referencia",
+            "code"
+        ],
+        "referencialaltim": [
+            "referencial_altim",
+            "code"
+        ],
+        "referencialgrav": [
+            "referencial_grav",
+            "code"
+        ],
+        "sistemageodesico": [
+            "sistema_geodesico",
+            "code"
+        ],
+        "situacaomarco": [
+            "situacao_marco",
+            "code"
+        ],
+        "tipoptorefgeodtopo": [
+            "tipo_pto_ref_geod_topo",
+            "code"
+        ],
+        "tiporef": [
+            "tipo_ref",
+            "code"
+        ]
+    },
+    "edgv_rel_alteracao_fisiografica_antropica_a": {
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_alteracao_fisiografica_antropica_l": {
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_alteracao_fisiografica_antropica_p": {
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_aterro_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_aterro_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_aterro_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_corte_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_corte_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_corte_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "tipoalterantrop": [
+            "tipo_alter_antrop",
+            "code"
+        ]
+    },
+    "edgv_rel_curva_nivel_l": {
+        "tipocurvanivel": [
+            "tipo_curva_nivel",
+            "code"
+        ]
+    },
+    "edgv_rel_dolina_a": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_dolina_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_duna_a": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_duna_l": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_duna_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_elemento_fisiografico_natural_a": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_elemento_fisiografico_natural_l": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_elemento_fisiografico_natural_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_gruta_caverna_l": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_gruta_caverna_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_pico_p": {
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_rocha_a": {
+        "formarocha": [
+            "forma_rocha",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_rocha_l": {
+        "formarocha": [
+            "forma_rocha",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_rocha_p": {
+        "formarocha": [
+            "forma_rocha",
+            "code"
+        ],
+        "tipoelemnat": [
+            "tipo_elem_nat",
+            "code"
+        ]
+    },
+    "edgv_rel_terreno_exposto_a": {
+        "causaexposicao": [
+            "causa_exposicao",
+            "code"
+        ],
+        "tipoterrexp": [
+            "tipo_terreno_exposto",
+            "code"
+        ]
+    },
+    "edgv_rod_trecho_rodoviario_a": {
+        "acostamento": [
+            "auxiliar",
+            "code"
+        ],
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteirodivisorio": [
+            "auxiliar",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipovia": [
+            "tipo_via",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ],
+        "trechoemperimetrourbano": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_rod_trecho_rodoviario_l": {
+        "acostamento": [
+            "auxiliar",
+            "code"
+        ],
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "canteirodivisorio": [
+            "auxiliar",
+            "code"
+        ],
+        "jurisdicao": [
+            "jurisdicao",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "revestimento": [
+            "revestimento",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipovia": [
+            "tipo_via",
+            "code"
+        ],
+        "trafego": [
+            "trafego",
+            "code"
+        ],
+        "trechoemperimetrourbano": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_snb_barragem_calcadao_a": {
+        "localizacaoequipdesenvsocial": [
+            "local_equip_desenv_social",
+            "code"
+        ],
+        "tipoequipdesenvsocial": [
+            "tipo_equip_desenv_social",
+            "code"
+        ]
+    },
+    "edgv_snb_dep_abast_agua_a": {
+        "estadofisico": [
+            "estado_fisico",
+            "code"
+        ],
+        "finalidadedep": [
+            "finalidade_deposito",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoagua": [
+            "situacao_agua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipo_conteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipo_dep_geral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipo_produto_residuo",
+            "code"
+        ],
+        "tratamento": [
+            "auxiliar",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidade_volume",
+            "code"
+        ]
+    },
+    "edgv_snb_dep_abast_agua_p": {
+        "estadofisico": [
+            "estado_fisico",
+            "code"
+        ],
+        "finalidadedep": [
+            "finalidade_deposito",
+            "code"
+        ],
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoagua": [
+            "situacao_agua",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipoconteudo": [
+            "tipo_conteudo",
+            "code"
+        ],
+        "tipodepgeral": [
+            "tipo_dep_geral",
+            "code"
+        ],
+        "tipoexposicao": [
+            "tipo_exposicao",
+            "code"
+        ],
+        "tipoprodutoresiduo": [
+            "tipo_produto_residuo",
+            "code"
+        ],
+        "tratamento": [
+            "auxiliar",
+            "code"
+        ],
+        "unidadevolume": [
+            "unidade_volume",
+            "code"
+        ]
+    },
+    "edgv_tra_caminho_aereo_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipocaminhoaereo": [
+            "tipo_caminho_aereo",
+            "code"
+        ],
+        "tipousocaminhoaer": [
+            "tipo_transporte",
+            "code"
+        ]
+    },
+    "edgv_tra_entroncamento_pto_p": {
+        "tipoentroncamento": [
+            "tipo_entroncamento",
+            "code"
+        ]
+    },
+    "edgv_tra_funicular_l": {
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_tra_passagem_elevada_viaduto_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopassagviad": [
+            "tipo_passag_viad",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ]
+    },
+    "edgv_tra_passagem_elevada_viaduto_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopassagviad": [
+            "tipo_passag_viad",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ]
+    },
+    "edgv_tra_passagem_elevada_viaduto_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopassagviad": [
+            "tipo_passag_viad",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ]
+    },
+    "edgv_tra_patio_a": {
+        "administracao": [
+            "administracao",
+            "code"
+        ],
+        "finalidadepatio": [
+            "finalidade_patio",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ]
+    },
+    "edgv_tra_ponte_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipoponte": [
+            "tipo_ponte",
+            "code"
+        ]
+    },
+    "edgv_tra_ponte_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipoponte": [
+            "tipo_ponte",
+            "code"
+        ]
+    },
+    "edgv_tra_ponte_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipoponte": [
+            "tipo_ponte",
+            "code"
+        ]
+    },
+    "edgv_tra_travessia_l": {
+        "tipoembarcacao": [
+            "tipo_embarcacao",
+            "code"
+        ],
+        "tipotravessia": [
+            "tipo_travessia",
+            "code"
+        ],
+        "tipouso": [
+            "tipo_transporte",
+            "code"
+        ]
+    },
+    "edgv_tra_travessia_p": {
+        "tipoembarcacao": [
+            "tipo_embarcacao",
+            "code"
+        ],
+        "tipotravessia": [
+            "tipo_travessia",
+            "code"
+        ],
+        "tipouso": [
+            "tipo_transporte",
+            "code"
+        ]
+    },
+    "edgv_tra_travessia_pedestre_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotravessiaped": [
+            "tipo_travessia_ped",
+            "code"
+        ]
+    },
+    "edgv_tra_travessia_pedestre_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotravessiaped": [
+            "tipo_travessia_ped",
+            "code"
+        ]
+    },
+    "edgv_tra_travessia_pedestre_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "situacaoespacial": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipotravessiaped": [
+            "tipo_travessia_ped",
+            "code"
+        ]
+    },
+    "edgv_tra_tunel_a": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipotunel": [
+            "tipo_tunel",
+            "code"
+        ]
+    },
+    "edgv_tra_tunel_l": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipotunel": [
+            "tipo_tunel",
+            "code"
+        ]
+    },
+    "edgv_tra_tunel_p": {
+        "matconstr": [
+            "mat_constr",
+            "code"
+        ],
+        "modaluso": [
+            "modal_uso",
+            "code"
+        ],
+        "necessitamanutencao": [
+            "auxiliar",
+            "code"
+        ],
+        "operacional": [
+            "auxiliar",
+            "code"
+        ],
+        "posicaopista": [
+            "situacao_espacial",
+            "code"
+        ],
+        "situacaofisica": [
+            "situacao_fisica",
+            "code"
+        ],
+        "tipopavimentacao": [
+            "tipo_pavimentacao",
+            "code"
+        ],
+        "tipotunel": [
+            "tipo_tunel",
+            "code"
+        ]
+    },
+    "edgv_veg_brejo_pantano_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_veg_caatinga_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_veg_campinarana_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_veg_campo_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ],
+        "tipocampo": [
+            "tipo_campo",
+            "code"
+        ]
+    },
+    "edgv_veg_cerrado_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ],
+        "vereda": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_veg_floresta_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "especiepredominante": [
+            "especie",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_veg_mangue_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ],
+        "tipomanguezal": [
+            "tipo_manguezal",
+            "code"
+        ]
+    },
+    "edgv_veg_reflorestamento_a": {
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "cultivopredominante": [
+            "cultivo_predominante",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_cultura",
+            "code"
+        ],
+        "terreno": [
+            "condicao_terreno",
+            "code"
+        ],
+        "tipolavoura": [
+            "tipo_lavoura",
+            "code"
+        ]
+    },
+    "edgv_veg_veg_area_contato_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ],
+        "tipoveg": [
+            "tipo_vegetacao",
+            "code"
+        ]
+    },
+    "edgv_veg_veg_cultivada_a": {
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "cultivopredominante": [
+            "cultivo_predominante",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_cultura",
+            "code"
+        ],
+        "terreno": [
+            "condicao_terreno",
+            "code"
+        ],
+        "tipolavoura": [
+            "tipo_lavoura",
+            "code"
+        ]
+    },
+    "edgv_veg_veg_restinga_a": {
+        "antropizada": [
+            "auxiliar",
+            "code"
+        ],
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "densidade": [
+            "densidade",
+            "code"
+        ],
+        "secundaria": [
+            "auxiliar",
+            "code"
+        ]
+    },
+    "edgv_ver_jardim_a": {
+        "classificacaoporte": [
+            "classificacao_porte",
+            "code"
+        ],
+        "cultivopredominante": [
+            "cultivo_predominante",
+            "code"
+        ],
+        "finalidade": [
+            "finalidade_cultura",
+            "code"
+        ],
+        "terreno": [
+            "condicao_terreno",
+            "code"
+        ],
+        "tipolavoura": [
+            "tipo_lavoura",
+            "code"
+        ]
+    }
+}

--- a/core/Factories/DbFactory/abstractDb.py
+++ b/core/Factories/DbFactory/abstractDb.py
@@ -746,7 +746,11 @@ class AbstractDb(QObject):
             qmlPath = self.getQmlDir()
             return self.utils.parseMultiQml(qmlPath, layerList)
         else:
-            qmlRecordDict = self.getQmlRecordDict(layerList)
+            try:
+                qmlRecordDict = self.getQmlRecordDict(layerList)
+            except:
+                qmlPath = self.getQmlDir()
+                return self.utils.parseMultiQml(qmlPath, layerList)
             return self.utils.parseMultiFromDb(qmlRecordDict, layerList)
     
     def getQmlRecordDict(self, inputLayer):
@@ -768,7 +772,10 @@ class AbstractDb(QObject):
     
     def getQml(self, layerName):
         if self.getDatabaseVersion() == '3.0':
-            return (self.getQmlRecordDict(layerName), 'db')
+            try:
+                return (self.getQmlRecordDict(layerName), 'db')
+            except:
+                return (self.getQmlDir(), 'dir')
         else:
             return (self.getQmlDir(), 'dir')
 

--- a/core/Factories/DbFactory/spatialiteDb.py
+++ b/core/Factories/DbFactory/spatialiteDb.py
@@ -607,3 +607,19 @@ class SpatialiteDb(AbstractDb):
             rowDict['srid'] = str(query.value(3))
             out.append(rowDict)
         return out
+
+    def tableFields(self, table):
+        """
+        Gets all attribute names for a table.
+        :param table: (str) table name.
+        :return: (list-of-str) list of attribute names.
+        """
+        attrs = list()
+        self.checkAndOpenDb()
+        sql = self.gen.tableFields(table)
+        query = QSqlQuery(sql, self.db)
+        if not query.isActive():
+            raise Exception(self.tr("Problem getting geom tuple list: ")+query.lastError().text())
+        while query.next():
+            attrs.append(query.value(1))
+        return attrs

--- a/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
@@ -21,20 +21,19 @@
  ***************************************************************************/
 """
 import os
-from xml.dom.minidom import parse, parseString
 
-# Qt imports
-from qgis.PyQt import QtGui, uic, QtCore
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal, QVariant
+from qgis.core import (Qgis,
+                       QgsField,
+                       QgsWkbTypes,
+                       QgsMessageLog,
+                       QgsVectorLayer,
+                       QgsDataSourceUri,
+                       QgsVectorLayerJoinInfo)
+from qgis.utils import iface
+from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.Qt import QObject
 
-# QGIS imports
-from qgis.core import QgsVectorLayer,QgsDataSourceUri, QgsMessageLog, QgsField, \
-                      QgsWkbTypes, QgsVectorLayerJoinInfo
-from qgis.utils import iface
-
-#DsgTools imports
-from ...Utils.utils import Utils
+from DsgTools.core.Utils.utils import Utils
 
 class EDGVLayerLoader(QObject):
     

--- a/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/edgvLayerLoader.py
@@ -32,6 +32,7 @@ from qgis.core import (Qgis,
 from qgis.utils import iface
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.Qt import QObject
+from qgis.PyQt.QtXml import QDomDocument
 
 from DsgTools.core.Utils.utils import Utils
 
@@ -214,7 +215,12 @@ class EDGVLayerLoader(QObject):
             QgsMessageLog.logMessage(':'.join(e.args), "DSGTools Plugin", Qgis.Critical)
             return None
         if qmlType == 'db':
-            vlayer.importNamedStyle(qmldir)
+            tempPath = os.path.join(os.path.dirname(__file__), "temp.qml")
+            with open(tempPath, "w", encoding='utf-8') as f:
+                f.writelines(qmldir)
+                f.close()
+            vlayer.loadNamedStyle(tempPath, True)
+            os.remove(tempPath)
         else:
             vlayerQml = os.path.join(qmldir, vlayer.name()+'.qml')
             #treat case of qml with multi

--- a/core/Factories/LayerLoaderFactory/spatialiteLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/spatialiteLayerLoader.py
@@ -89,9 +89,14 @@ class SpatialiteLayerLoader(EDGVLayerLoader):
         edgvVersion = self.abstractDb.getDatabaseVersion()
         rootNode = QgsProject.instance().layerTreeRoot()
         dbNode = self.getDatabaseGroup(rootNode)
-        #3. Load Domains
-        #do this only if EDGV Version = FTer
-        domLayerDict = self.loadDomains(filteredLayerList, dbNode, edgvVersion)
+        # #3. Load Domains
+        # #do this only if EDGV Version = FTer
+        # domLayerDict = self.loadDomains(filteredLayerList, dbNode, edgvVersion)
+        # NOTE: iface.interfaceLegend() has changed and loadDomain must change its signature.
+        #       since this whole feature MUST be refactored and domain tables are not to be
+        #       loaded in any of our current use cases, this will be ignored and set to an
+        #       empty dict
+        domLayerDict = dict()
         #4. Get Aux dicts
         lyrDict = self.getLyrDict(filteredDictList, isEdgv = isEdgv)
         #5. Build Groups

--- a/core/Factories/LayerLoaderFactory/spatialiteLayerLoader.py
+++ b/core/Factories/LayerLoaderFactory/spatialiteLayerLoader.py
@@ -21,17 +21,18 @@
  ***************************************************************************/
 """
 import os
+import json
+from collections import defaultdict
 
-# Qt imports
-from qgis.PyQt import QtGui, uic, QtCore
-from qgis.PyQt.QtCore import pyqtSlot, pyqtSignal
-from qgis.PyQt.Qt import QObject
+from qgis.core import (Qgis,
+                       QgsProject,
+                       QgsMessageLog,
+                       QgsVectorLayer,
+                       QgsDataSourceUri,
+                       QgsEditorWidgetSetup,
+                       QgsCoordinateReferenceSystem)
+from qgis.PyQt.QtSql import QSqlQuery
 
-# QGIS imports
-from qgis.core import QgsVectorLayer,QgsDataSourceUri, QgsMessageLog, QgsCoordinateReferenceSystem, QgsMessageLog, Qgis, QgsProject, QgsEditorWidgetSetup
-from qgis.utils import iface
-
-#DsgTools imports
 from .edgvLayerLoader import EDGVLayerLoader
 from ....gui.CustomWidgets.BasicInterfaceWidgets.progressWidget import ProgressWidget
 
@@ -71,6 +72,98 @@ class SpatialiteLayerLoader(EDGVLayerLoader):
                 if database == candidateUri.database():
                     return ll
         return loaded
+
+    def specialEdgvAttributes(self):
+        """
+        Gets the list of attributes shared by many EDGV classes and have a different domain
+        depending on which category the EDGV class belongs to.
+        :return: (list-of-str) list of "special" EDGV classes. 
+        """
+        return ["finalidade", "relacionado", "coincidecomdentrode", "tipo"]
+
+    def tableFields(self, table):
+        """
+        Gets all attribute names for a table.
+        :return: (list-of-str) list of attribute names.
+        """
+        return self.abstractDb.tableFields(table)
+
+    def domainMapping(self, modelVersion):
+        """
+        Identifies wich table and attribute is related to all tables available
+        in the database that has a mapping (FK to a domain table).
+        :param modelVersion: (str) which model version is identified (e.g. 3.0)
+        :return: (dict) mapping from each layer's attributes to its FK relative
+        - Mapping format:
+            {
+                "schema_layer_name": {
+                    "layer_attribute_name": [
+                        "domain_table_name",
+                        "domain_refereced_attribute_name"
+                    ]
+                }
+            }
+        """
+        basePath = os.path.join(
+            os.path.dirname(__file__), "..", "..", "DbModels", "DomainMapping")
+        path = {
+            "EDGV 3.0": os.path.join(basePath, "edgv_3.json"),
+            "3.0": os.path.join(basePath, "edgv_3.json"),
+            "EDGV 2.1.3 Pro": os.path.join(basePath, "edgv_213_pro.json"),
+            "2.1.3 Pro": os.path.join(basePath, "edgv_213_pro.json"),
+            "EDGV 2.1.3": os.path.join(basePath, "edgv_213.json"),
+            "2.1.3": os.path.join(basePath, "edgv_213.json")
+        }.pop(modelVersion, None)
+        if path is None or not os.path.exists(path):
+            return dict()
+        with open(path, "r") as fp:
+            # file generated based on PostGIS FK metadata
+            return json.load(fp)
+
+    def getAllEdgvDomainsFromTableName(self, schema, table):
+        """
+        EDGV databases deployed by DSGTools have a set of domain tables. Gets the value map from such DB.
+        It checks for all attributes found.
+        :param table: (str) layer to be checked for its EDGV mapping.
+        :return: (dict) value map for all attributes that have one.
+        """
+        self.abstractDb.checkAndOpenDb()
+        ret = defaultdict(dict)
+        db = self.abstractDb.db
+        edgv = self.abstractDb.getDatabaseVersion()
+        domainMap = self.domainMapping(edgv)
+        fullTablaName = schema + "_" + table
+        sql = 'select code, code_name from dominios_{field} order by code'
+        for fieldName in self.tableFields(fullTablaName):
+            if fullTablaName in domainMap:
+                domains = domainMap[fullTablaName]
+                # if domain mapping is not yet available for current version
+                if fieldName in domains:
+                    # replace this method over querying db for the table...
+                    domainTable = domains[fieldName][0]
+                else:
+                    # non-mapped attribute
+                    continue
+                query = QSqlQuery(sql.format(field=domainTable), db)
+            elif fieldName in self.specialEdgvAttributes():
+                # EDGV "special" attributes that are have different domains depending on
+                # which class it belongs to
+                if edgv in ("2.1.3 Pro", "3.0 Pro"):
+                    # Pro versions now follow the logic "{attribute}_{CLASS_NAME}"
+                    cat = table.rsplit("_", 1)[0].split("_", 1)[-1]
+                else:
+                    cat = table.split("_")[0]
+                attrTable = "{attribute}_{cat}".format(attribute=fieldName, cat=cat)
+                query = QSqlQuery(sql.format(field=attrTable), db)
+            else:
+                query = QSqlQuery(sql.format(field=fieldName), db)
+            if not query.isActive():
+                continue
+            while query.next():
+                code = str(query.value(0))
+                code_name = query.value(1)
+                ret[fieldName][code_name] = code
+        return ret
 
     def load(self, inputList, useQml=False, uniqueLoad=False, useInheritance=False, stylePath=None, onlyWithElements=False, geomFilterList=[], isEdgv=True, customForm=False, editingDict=None, parent=None):
         """
@@ -154,17 +247,32 @@ class SpatialiteLayerLoader(EDGVLayerLoader):
         QgsProject.instance().addMapLayer(vlayer, addToLegend = False)
         crs = QgsCoordinateReferenceSystem(int(srid), QgsCoordinateReferenceSystem.EpsgCrsId)
         vlayer.setCrs(crs)
-        vlayer = self.setDomainsAndRestrictionsWithQml(vlayer)
-        vlayer = self.setMulti(vlayer,domLayerDict)
+        # vlayer = self.setDomainsAndRestrictionsWithQml(vlayer)
+        # vlayer = self.setMulti(vlayer, domLayerDict)
+        self.setDomainMappingToLayer(vlayer, schema)
         if stylePath:
             fullPath = self.getStyle(stylePath, tableName)
             if fullPath:
                 vlayer.loadNamedStyle(fullPath, True)
-        parentNode.addLayer(vlayer) 
-        if not vlayer.isValid():
-            QgsMessageLog.logMessage(vlayer.error().summary(), "DSGTools Plugin", Qgis.Critical)
+        parentNode.addLayer(vlayer)
         vlayer = self.createMeasureColumn(vlayer)
         return vlayer
+
+    def setDomainMappingToLayer(self, layer, schema):
+        """
+        Sets the maps the attributes that are represented as value maps on the
+        EDGV implementation for a given layer.
+        :param layer: (QgsVectorLayer) layer to have its attributes mapped.
+        :param schema: (str) first "part" of table names in SpatiaLite
+                       implementations of EDGV from DSGTools. They are
+                       equivalent to the schema in PostgreSQL implementations.
+        """
+        fields = layer.fields()
+        mappings = self.getAllEdgvDomainsFromTableName(schema, layer.name())
+        for field, valueMap in mappings.items():
+            fieldIndex = fields.indexFromName(field)
+            widgetSetup = QgsEditorWidgetSetup("ValueMap", {"map": valueMap})
+            layer.setEditorWidgetSetup(fieldIndex, widgetSetup)
 
     def loadDomain(self, domainTableName, domainGroup):
         """
@@ -178,7 +286,7 @@ class SpatialiteLayerLoader(EDGVLayerLoader):
         uri.setDatabase(self.abstractDb.db.databaseName())
         uri.setDataSource('', 'dominios_'+domainTableName, None)
         #TODO Load domain layer into a group
-        domLayer = iface.addVectorLayer(uri.uri(), domainTableName, self.provider)
+        domLayer = self.iface.addVectorLayer(uri.uri(), domainTableName, self.provider)
         self.iface.legendInterface().moveLayer(domLayer, domainGroup)
         return domLayer
 

--- a/core/Factories/SqlFactory/spatialiteSqlGenerator.py
+++ b/core/Factories/SqlFactory/spatialiteSqlGenerator.py
@@ -232,3 +232,11 @@ class SpatialiteSqlGenerator(SqlGenerator):
         :return: (str) query to database's implementation version (e.g. '5.2').
         """
         return """SELECT dbimplversion FROM public_db_metadata;"""
+
+    def tableFields(self, table):
+        """
+        Gets all attribute names for a table.
+        :param table: (str) table name.
+        :return: (list-of-str) list of attribute names.
+        """
+        return """PRAGMA table_info('{0}');""".format(table)

--- a/core/Utils/utils.py
+++ b/core/Utils/utils.py
@@ -153,7 +153,7 @@ class Utils(object):
                 doc = parse(qml)
                 refDict[lyr] = dict()
                 for node in doc.getElementsByTagName('edittype'):
-                    if node.getAttribute('widgetv2type') == 'ValueRelation':
+                    if node.getAttribute('widgetv2type') in ('ValueMap', 'ValueRelation'):
                         attrName = node.getAttribute('name')
                         refDict[lyr][attrName] = node.getElementsByTagName(
                             'widgetv2config')[0].getAttribute('Layer')

--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=DSG Tools
 qgisMinimumVersion=3.2
 description=Brazilian Army Cartographic Production Tools
-version=4.1
+version=4.2_dev
 author=Brazilian Army Geographic Service
 email=suporte.dsgtools@dsg.eb.mil.br
 about=

--- a/metadata.txt
+++ b/metadata.txt
@@ -10,7 +10,7 @@
 name=DSG Tools
 qgisMinimumVersion=3.2
 description=Brazilian Army Cartographic Production Tools
-version=4.2_dev
+version=4.2_edf70a3f3fae71484d1deaf3ed45d6b7859b07c2
 author=Brazilian Army Geographic Service
 email=suporte.dsgtools@dsg.eb.mil.br
 about=


### PR DESCRIPTION
Temporary solution.

Problem: EDGV 3.0 database structure changed and old QML containing domain data are not compatible with QGIS 3 (so it seems).

Solution: generated a JSON containing the full mapping based on database's structure and added methods designed to read these methods. This is not ideal as it adds a new element that has to be updated as the implementation gets updated.

The solution, however not ideal, is supposed to be temporary: the layer loader (and database connection classes) are planned to be refactored soon and this would be included in it.