### PR TITLE
Dev #550

### DIFF
--- a/core/Factories/DbFactory/abstractDb.py
+++ b/core/Factories/DbFactory/abstractDb.py
@@ -20,30 +20,21 @@
  *                                                                         *
  ***************************************************************************/
 """
-from builtins import map
-from builtins import str
-from builtins import range
-import os, binascii
-from uuid import uuid4, UUID
 
+import os
+from uuid import uuid4, UUID
 from osgeo import ogr, osr
 
-# DsgTools imports
-from ..SqlFactory.sqlGeneratorFactory import SqlGeneratorFactory
+from qgis.core import Qgis, QgsMessageLog, QgsCoordinateReferenceSystem
+from qgis.PyQt.QtSql import QSqlQuery
+from qgis.PyQt.QtCore import pyqtSignal, QObject
+
 from ...Utils.utils import Utils
 from DsgTools.core.Utils.FrameTools.map_index import UtmGrid
 
-#PyQt imports
-from qgis.PyQt.QtSql import QSqlQuery, QSqlDatabase
-from qgis.PyQt.QtCore import QSettings, pyqtSignal, QObject
-
-#Qgis imports
-import qgis.core 
-from qgis.core import QgsCoordinateReferenceSystem 
-
 class DbSignals(QObject):
-        updateLog = pyqtSignal(str)
-        clearLog = pyqtSignal()
+    updateLog = pyqtSignal(str)
+    clearLog = pyqtSignal()
 
 class AbstractDb(QObject):
     def __init__(self):
@@ -136,7 +127,19 @@ class AbstractDb(QObject):
                     schema = self.getTableSchemaFromDb(lyr)
             sql = self.gen.getElementCountFromLayerV2(schema, lyr, useInheritance)
             query = QSqlQuery(sql,self.db)
-            query.next()
+            if not query.next():
+                # use may not have permission to read the table from schema
+                QgsMessageLog.logMessage(
+                    self.tr("Unable to read table {0}. Error message: '{1}'")\
+                        .format(
+                            self.db.databaseName(),
+                            self.db.lastError().databaseText()
+                        ),
+                    "DSGTools Plugin",
+                    Qgis.Warning
+                )
+                continue
+
             if query.value(0) > 0:
                 lyrWithElemList.append(lyr)
         return lyrWithElemList
@@ -606,14 +609,14 @@ class AbstractDb(QObject):
         Gets the QML directory
         """
         currentPath = os.path.dirname(__file__)
-        if qgis.core.Qgis.QGIS_VERSION_INT >= 30000:
+        if Qgis.QGIS_VERSION_INT >= 30000:
             # treat old implementations (bug fixes on domain values)
             implVersion = self.implementationVersion()
             if implVersion == '' or float(implVersion) < 3:
                 qmlVersionPath = os.path.join(currentPath, '..', '..', 'Qmls', 'qgis_37_impl_2')
             else:
                 qmlVersionPath = os.path.join(currentPath, '..', '..', 'Qmls', 'qgis_37')
-        elif qgis.core.Qgis.QGIS_VERSION_INT >= 20600:
+        elif Qgis.QGIS_VERSION_INT >= 20600:
             qmlVersionPath = os.path.join(currentPath, '..', '..', 'Qmls', 'qgis_26')
         else:
             qmlVersionPath = os.path.join(currentPath, '..', '..', 'Qmls', 'qgis_22')

--- a/core/Factories/DbFactory/postgisDb.py
+++ b/core/Factories/DbFactory/postgisDb.py
@@ -20,13 +20,15 @@
  *                                                                         *
  ***************************************************************************/
 """
-from builtins import map
-from builtins import str
-from builtins import range
 
+from qgis.core import Qgis
 from qgis.PyQt.QtSql import QSqlQuery, QSqlDatabase
 from qgis.PyQt.QtCore import QSettings
-from qgis.core import QgsCredentials, QgsMessageLog, QgsDataSourceUri, QgsFeature, QgsVectorLayer, QgsField
+from qgis.core import (Qgis,
+                       QgsMessageLog,
+                       QgsCredentials,
+                       QgsVectorLayer,
+                       QgsDataSourceUri)
 
 from .abstractDb import AbstractDb
 from ..SqlFactory.sqlGeneratorFactory import SqlGeneratorFactory
@@ -807,7 +809,13 @@ class PostgisDb(AbstractDb):
                 db.setUserName(self.db.userName())
                 db.setPassword(self.db.password())
                 if not db.open():
-                    raise Exception(self.tr("Problem opening databases: ")+db.lastError().databaseText())
+                    # raise Exception(self.tr("Problem opening databases: ")+db.lastError().databaseText())
+                    QgsMessageLog.logMessage(
+                        self.tr("Unable to load {0}").format(database),
+                        "DSGTools Plugin",
+                        Qgis.Warning
+                    )
+                    continue
 
                 query2 = QSqlQuery(db)
                 if query2.exec_(self.gen.getGeometryTablesCount()):

--- a/core/Factories/DbFactory/postgisDb.py
+++ b/core/Factories/DbFactory/postgisDb.py
@@ -811,7 +811,8 @@ class PostgisDb(AbstractDb):
                 if not db.open():
                     # raise Exception(self.tr("Problem opening databases: ")+db.lastError().databaseText())
                     QgsMessageLog.logMessage(
-                        self.tr("Unable to load {0}").format(database),
+                        self.tr("Unable to load {0}. Error message: '{1}'")\
+                            .format(database, db.lastError().databaseText()),
                         "DSGTools Plugin",
                         Qgis.Warning
                     )

--- a/core/Factories/DbFactory/postgisDb.py
+++ b/core/Factories/DbFactory/postgisDb.py
@@ -828,9 +828,21 @@ class PostgisDb(AbstractDb):
                                 while query3.next():
                                     version = query3.value(0)
                                     if version:
-                                        edvgDbList.append((database,version))
+                                        edvgDbList.append((database, version))
                                     else:
-                                        edvgDbList.append((database,'Non_EDGV'))
+                                        edvgDbList.append(
+                                            (database, 'Non_EDGV'))
+                            elif "42501" in query3.lastError().databaseText():
+                                # user may have some privileges on database,
+                                # but may not be granted on all schemas of a
+                                # database
+                                QgsMessageLog.logMessage(
+                                    self.tr("Unable to load '{0}'. User '{1}'"
+                                            " has insufficient privileges.")\
+                                        .format(database, db.userName()),
+                                    "DSGTools Plugin",
+                                    Qgis.Warning
+                                )
                             else:
                                 edvgDbList.append((database,'Non_EDGV'))
                 if parentWidget:


### PR DESCRIPTION
Problemas de identificação de permissão de usuário no banco geravam erros que, consequentemente, levavam a não identificação dos demais bancos, independente destes estarem liberados ao usuário.

Modificações:
- limpeza de `imports`;
- tratamento unitário de identificação de bancos, de modo a, caso dê algum erro no processamento de uma única unidade, não afete às demais. Foi adicionada, também, uma mensagem de erro no _log_ do _plugin_ no QGIS, de modo que o usuário esteja ciente do motivo (ou ao menos ajudar a identificar o problema); e
- após isso, pode ser que ainda haja problemas de permissão para algum _schema_ ou _tabela_ específicos, então foi utilizada a mesma estratégia no método de identificação de camadas.

Pode ser que ainda exista outros problemas decorrentes da permissão, porém serão sanados conforme identificados e, posteriormente, terão uma solução mais assertiva quando for feita a refatoração dos objetos de abstração de bancos e datasets.

Sugere-se um único método de avaliação de permissões mínimas necessárias a um usuário comum do DSGTools. Estas permissões devem, inclusive, ser pouco invasivas à gerência do banco (e.g. um não admin deve poder utilizar o DSGTools normalmente).