### PR TITLE
dev_#521

### DIFF
--- a/core/Factories/DbFactory/postgisDb.py
+++ b/core/Factories/DbFactory/postgisDb.py
@@ -3271,39 +3271,39 @@ class PostgisDb(AbstractDb):
         r = {'root':inhTreeDict}
         return r
     
-    def getInheritanceConstraintDict(self):
-        """
-        Returns a dict in the form:
-            {'tableName':{'attributeName': {'tableName','constraintName', 'filter'} 
-                }
-            }
-        """
-        self.checkAndOpenDb()
-        schemaList = [i for i in self.getGeometricSchemaList() if i not in ['views', 'validation']]
-        sql = self.gen.getConstraintDict(schemaList)
-        query = QSqlQuery(sql, self.db)
-        if not query.isActive():
-            raise Exception(self.tr("Problem constraint dict from db: ")+query.lastError().text())
-        inhConstrDict = dict()
-        while query.next():
-            queryResult = json.loads(query.value(0))
-            tableName = queryResult['tablename']
-            if tableName not in list(inhConstrDict.keys()):
-                inhConstrDict[tableName] = dict()
-            defList = queryResult['array_agg']
-            for value in defList:
-                constraintName = value['f1'] 
-                constraintDef = value['f2']
-                attrName = constraintName.split('_')[-2]
-                currTableName = constraintName.split('_'+attrName)[0]
-                if attrName not in list(inhConstrDict[tableName].keys()):
-                    inhConstrDict[tableName][attrName] = []
-                filterDef = self.parseCheckConstraintQuery(constraintName,constraintDef)[-1]
-                schema = self.getTableSchemaFromDb(currTableName)
-                currTag = {'schema':schema, 'tableName':currTableName, 'constraintName':constraintName, 'filter':filterDef}
-                if currTag not in inhConstrDict[tableName][attrName]:
-                    inhConstrDict[tableName][attrName].append(currTag)
-        return inhConstrDict
+    # def getInheritanceConstraintDict(self):
+    #     """
+    #     Returns a dict in the form:
+    #         {'tableName':{'attributeName': {'tableName','constraintName', 'filter'} 
+    #             }
+    #         }
+    #     """
+    #     self.checkAndOpenDb()
+    #     schemaList = [i for i in self.getGeometricSchemaList() if i not in ['views', 'validation']]
+    #     sql = self.gen.getConstraintDict(schemaList)
+    #     query = QSqlQuery(sql, self.db)
+    #     if not query.isActive():
+    #         raise Exception(self.tr("Problem constraint dict from db: ")+query.lastError().text())
+    #     inhConstrDict = dict()
+    #     while query.next():
+    #         queryResult = json.loads(query.value(0))
+    #         tableName = queryResult['tablename']
+    #         if tableName not in list(inhConstrDict.keys()):
+    #             inhConstrDict[tableName] = dict()
+    #         defList = queryResult['array_agg']
+    #         for value in defList:
+    #             constraintName = value['f1'] 
+    #             constraintDef = value['f2']
+    #             attrName = constraintName.split('_')[-2]
+    #             currTableName = constraintName.split('_'+attrName)[0]
+    #             if attrName not in list(inhConstrDict[tableName].keys()):
+    #                 inhConstrDict[tableName][attrName] = []
+    #             filterDef = self.parseCheckConstraintQuery(constraintName,constraintDef)[-1]
+    #             schema = self.getTableSchemaFromDb(currTableName)
+    #             currTag = {'schema':schema, 'tableName':currTableName, 'constraintName':constraintName, 'filter':filterDef}
+    #             if currTag not in inhConstrDict[tableName][attrName]:
+    #                 inhConstrDict[tableName][attrName].append(currTag)
+    #     return inhConstrDict
     
     def getDefaultFromDb(self, schema, tableName, attrName):
         """

--- a/core/Factories/SqlFactory/postgisSqlGenerator.py
+++ b/core/Factories/SqlFactory/postgisSqlGenerator.py
@@ -961,16 +961,16 @@ class PostGISSqlGenerator(SqlGenerator):
         sql = """delete from public.layer_styles where description = '{0}'""".format(styleName)
         return sql
     
-    def getConstraints(self, schemaList):
-        sql = """select sch.nspname, cl.relname, c.conname, c.consrc from 
-            (
-                select * from pg_constraint where contype = 'c'
-            ) as c join (
-                select oid, nspname from pg_namespace where nspname in ({0})
-            ) as sch on sch.oid = c.connamespace
-            left join pg_class as cl on c.conrelid = cl.oid
-            """.format(','.schemaList)
-        return sql
+    # def getConstraints(self, schemaList):
+    #     sql = """select sch.nspname, cl.relname, c.conname, c.consrc from 
+    #         (
+    #             select * from pg_constraint where contype = 'c'
+    #         ) as c join (
+    #             select oid, nspname from pg_namespace where nspname in ({0})
+    #         ) as sch on sch.oid = c.connamespace
+    #         left join pg_class as cl on c.conrelid = cl.oid
+    #         """.format(','.schemaList)
+    #     return sql
     
     def getGeometricSchemas(self):
         sql = 'select distinct f_table_schema from public.geometry_columns'
@@ -1380,18 +1380,18 @@ class PostGISSqlGenerator(SqlGenerator):
         sql = """ select code from dominios.{0}""".format(domainTable)
         return sql
     
-    def getConstraintDict(self, domainList):
-        sql = """select row_to_json(result) from (
-        select a.tn as tablename, array_agg(row_to_json(row(a.conname::text, a.consrc::text))) from (select sch.nspname as sch, cl.relname as tn, c.conname as conname, c.consrc as consrc from 
-                (
-                    select * from pg_constraint where contype = 'c'
-                ) as c join (
-                    select oid, nspname from pg_namespace where nspname in ('{0}')
-                ) as sch on sch.oid = c.connamespace
-                left join pg_class as cl on c.conrelid = cl.oid) as a where a.tn in (select f_table_name from public.geometry_columns) group by a.tn order by a.tn
-        ) as result
-        """.format("""','""".join(domainList))
-        return sql
+    # def getConstraintDict(self, domainList):
+    #     sql = """select row_to_json(result) from (
+    #     select a.tn as tablename, array_agg(row_to_json(row(a.conname::text, a.consrc::text))) from (select sch.nspname as sch, cl.relname as tn, c.conname as conname, c.consrc as consrc from 
+    #             (
+    #                 select * from pg_constraint where contype = 'c'
+    #             ) as c join (
+    #                 select oid, nspname from pg_namespace where nspname in ('{0}')
+    #             ) as sch on sch.oid = c.connamespace
+    #             left join pg_class as cl on c.conrelid = cl.oid) as a where a.tn in (select f_table_name from public.geometry_columns) group by a.tn order by a.tn
+    #     ) as result
+    #     """.format("""','""".join(domainList))
+    #     return sql
 
     def getDefaultFromDb(self, schema, tableName, attrName):
         sql = """select column_default from information_schema.columns where table_schema = '{0}' and table_name = '{1}' and column_name = '{2}';""".format(schema, tableName, attrName)


### PR DESCRIPTION
Coluna consrc foi removida das tabelas de metadados do PostgreSQL a partir da versão 12.

Existem métodos que utilizam esta coluna no código. Entretanto, estes métodos não estão sendo utilizados por quaisquer dos recursos ativos do DSGTools no momento.

São eles:

```python
PostgisDb.getInheritanceConstraintDict
PostGISSqlGenerator.getConstraints
PostGISSqlGenerator.getConstraintDict
```

Assim, foram apenas comentados no caso de existir algum uso não percebido, além de serem passíveis de uso na refatoração de código dos objetos de abstração de fontes de dados.