### PR TITLE
Algoritmo utils ExportFeaturesByAttribute

### DIFF
--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/ExportFeaturesByAttributeAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/ExportFeaturesByAttributeAlgorithm.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ DsgTools
+                                 A QGIS plugin
+ Brazilian Army Cartographic Production Tools
+                              -------------------
+        begin                : 2023-08-22
+        git sha              : $Format:%H$
+        copyright            : (C) 2023 by Matheus Alves Silva - Cartographic Engineer @ Brazilian Army
+        email                : matheus.silva@ime.eb.br
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.PyQt.QtCore import QCoreApplication, QVariant
+from qgis.core import (QgsProcessing,
+                       QgsProcessingException,
+                       QgsProcessingAlgorithm,
+                       QgsProcessingParameterVectorLayer,
+                       QgsProcessingParameterField,
+                       QgsProcessingParameterEnum,
+                       QgsProcessingParameterString,
+                       QgsProcessingParameterFeatureSink,
+                       QgsExpression,
+                       QgsFeatureSink,
+                       QgsVectorLayer,
+                       QgsFeatureRequest)
+from qgis import processing
+
+
+class ExportFeaturesByAttributeAlgorithm(QgsProcessingAlgorithm):
+    INPUT = 'INPUT'
+    FIELD = 'FIELD'
+    OPERATOR = 'OPERATOR'
+    VALUE = 'VALUE'
+    OUTPUT = 'OUTPUT'
+
+    OPERATORS = ['=',
+                 '<>',
+                 '>',
+                 '>=',
+                 '<',
+                 '<=',
+                 'begins with',
+                 'contains',
+                 'is null',
+                 'is not null',
+                 'does not contain'
+                 ]
+    STRING_OPERATORS = ['begins with', 'contains', 'does not contain']
+
+    def createInstance(self):
+        return ExportFeaturesByAttributeAlgorithm()
+
+    def name(self):
+        return 'ExportFeaturesByAttribute'
+
+    def displayName(self):
+        return self.tr('Export Features by Attribute')
+
+
+    def group(self):
+        """
+        Returns the name of the group this algorithm belongs to. This string
+        should be localised.
+        """
+        return self.tr("Utils")
+
+    def groupId(self):
+        """
+        Returns the unique ID of the group this algorithm belongs to. This
+        string should be fixed for the algorithm, and must not be localised.
+        The group id should be unique within each provider. Group id should
+        contain lowercase alphanumeric characters only and no spaces or other
+        formatting characters.
+        """
+        return "DSGTools - Utils"
+    
+    def tr(self, string):
+        return QCoreApplication.translate("Exports all features with a specified attribute value to a new layer", string
+    )
+
+
+    def shortHelpString(self):
+        return self.tr("Exports all features with a specified attribute value to a new layer with the name of the input layer suffixed with '_Output'.")
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(
+            QgsProcessingParameterVectorLayer(
+                self.INPUT,
+                self.tr('Input layer'),
+                [QgsProcessing.TypeVector]
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterField(
+                self.FIELD,
+                self.tr('Selection attribute'),
+                parentLayerParameterName=self.INPUT
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterEnum(
+                self.OPERATOR,
+                self.tr('Operator'),
+                options=self.OPERATORS,
+                defaultValue=0
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterString(
+                self.VALUE,
+                self.tr('Value'),
+                optional=True
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterFeatureSink(
+                self.OUTPUT,
+                self.tr('Output layer')
+            )
+        )
+
+    def processAlgorithm(self, parameters, context, feedback):
+        layer = self.parameterAsVectorLayer(parameters, self.INPUT, context)
+        fieldName = self.parameterAsString(parameters, self.FIELD, context)
+        operator = self.OPERATORS[self.parameterAsEnum(parameters, self.OPERATOR, context)]
+        value = self.parameterAsString(parameters, self.VALUE, context)
+
+        if layer is None:
+            feedback.pushInfo("Camada inválida ou não encontrada.")
+            return {self.OUTPUT: None}
+
+        if fieldName not in layer.fields().names():
+            feedback.pushInfo(f"O atributo '{fieldName}' não foi encontrado na camada. Nenhuma exportação realizada.")
+            return {self.OUTPUT: None}
+
+        # Construindo a expressão de seleção
+        field_ref = QgsExpression.quotedColumnRef(fieldName)
+        if operator == 'is null':
+            expression_string = f"{field_ref} IS NULL"
+        elif operator == 'is not null':
+            expression_string = f"{field_ref} IS NOT NULL"
+        elif operator == 'begins with':
+            expression_string = f"{field_ref} LIKE '{value}%'"
+        elif operator == 'contains':
+            expression_string = f"{field_ref} LIKE '%{value}%'"
+        elif operator == 'does not contain':
+            expression_string = f"{field_ref} NOT LIKE '%{value}%'"
+        else:
+            quoted_val = QgsExpression.quotedValue(value)
+            expression_string = f"{field_ref} {operator} {quoted_val}"
+
+        expression = QgsExpression(expression_string)
+        if expression.hasParserError():
+            feedback.pushInfo(f"Erro na expressão: {expression.parserErrorString()}")
+            return {self.OUTPUT: None}
+
+        # Configurando o sink para a camada de saída
+        (sink, dest_id) = self.parameterAsSink(
+            parameters,
+            self.OUTPUT,
+            context,
+            layer.fields(),
+            layer.wkbType(),
+            layer.sourceCrs()
+        )
+
+        # Verificando se há features que correspondem ao filtro
+        features = layer.getFeatures(QgsFeatureRequest(expression))
+        matched_features = [f for f in features]
+        if not matched_features:
+            feedback.pushInfo("Nenhum recurso encontrado com o valor especificado.")
+            return {self.OUTPUT: dest_id}
+
+        # Adiciona as features que correspondem ao filtro no sink
+        for feature in matched_features:
+            if feedback.isCanceled():
+                break
+            sink.addFeature(feature, QgsFeatureSink.FastInsert)
+
+        feedback.pushInfo("Exportação concluída com sucesso.")
+        return {self.OUTPUT: dest_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/dsgtoolsProcessingAlgorithmProvider.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/dsgtoolsProcessingAlgorithmProvider.py
@@ -224,6 +224,9 @@ from DsgTools.core.DSGToolsProcessingAlgs.Algs.OtherAlgs.selectFeaturesOnCurrent
 from DsgTools.core.DSGToolsProcessingAlgs.Algs.OtherAlgs.azimuthCalculationAlgorithm import (
     AzimuthCalculationAlgorithm,
 )
+from DsgTools.core.DSGToolsProcessingAlgs.Algs.OtherAlgs.ExportFeaturesByAttributeAlgorithm import (
+    ExportFeaturesByAttributeAlgorithm,
+)
 from DsgTools.core.DSGToolsProcessingAlgs.Algs.ValidationAlgs.addUnsharedVertexOnIntersectionsAlgorithm import (
     AddUnsharedVertexOnIntersectionsAlgorithm,
 )
@@ -687,6 +690,7 @@ class DSGToolsProcessingAlgorithmProvider(QgsProcessingProvider):
             FixSegmentErrorsBetweenLinesAlgorithm(),
             IdentifyDifferencesBetweenDatabaseModelsAlgorithm(),
             AzimuthCalculationAlgorithm(),
+            ExportFeaturesByAttributeAlgorithm(),
             DetectChangesBetweenGroups(),
             IdentifyWaterBodyAndContourInconsistencies(),
             CreateGridFromCoordinatesAlgorithm(),


### PR DESCRIPTION
O algoritmo ExportFeaturesByAttribute visa exportar feições com base em um atributo específico da camada. Ele permite selecionar e exportar feições de uma camada vetorial de acordo com um valor de atributo, usando operadores como "igual", "diferente", "contém", "não contém", e outros. Esse processo é útil para gerar subconjuntos de dados em uma nova camada vetorial com feições filtradas, permitindo análise e processamento específicos de dados espaciais de forma eficiente e automatizada. O algoritmo também pode ser utilizado em modelos quando houver necessidade de filtrar feições com base em seus atributos, especialmente quando a camada é "opcional" para o processamento.