### PR TITLE
docs: atualiza metadata.txt e README (release 5.2.0)

### DIFF
--- a/DsgTools/metadata.txt
+++ b/DsgTools/metadata.txt
@@ -16,27 +16,27 @@ version=5.2.0
 author=Brazilian Army Geographic Service
 email=dsgtools@dsg.eb.mil.br
 about=DSGTools with the following features:
-	-Creation, Storage and Deletion of PostGIS servers configurations
-	-Database creation using PostGIS according to EDGV version 2.1.3 and 3.0 (cadaster)
-	-Layer loading by category and class as defined by EDGV version 2.1.3 and EDGV version 3.0 (cadaster)
-	-Manipulation of complex features (Creation, Editing, Deletion, Zoom, Association, Disassociation) and
-	-Access to some WM(T)S services provided by BDGEx.
-	-Inventory Tool for all geospatial data supported by GDAL/OGR.
-	-Tool to install Models and Script (geoalgorithms) in the Processing Toolbox (HSV fusion script available).
-	-Database role management. Access profile (i.e. Read/Write permissions by table in database ).
-	-Database user profile management (e.g. Grant/Revoke predifined roles to/from user ).
-	-Create/Remove PostgreSQL users.
-	-Alter PostgreSQL user Password.
+	-Creation of PostGIS databases according to the EDGV 2.1.3, EDGV 3.0, EDGV 3.0 Pro, EDGV 3.0 Orto and EDGV 3.0 Topo models.
+	-Creation, storage and deletion of PostGIS server configurations.
 	-Conversion tools between PostGIS EDGV databases.
-	-Tool to assign elevation values to contour lines in a simple way.
+	-Database structure validation against the masterfile.
+	-Layer loading by class, category, geometric primitive and schema; tools to load shapefiles, PostGIS Raster layers and themes.
+	-Manipulation of complex features (Creation, Editing, Deletion, Zoom, Association, Disassociation).
+	-Classification and acquisition menus, right-angle and freehand acquisition tools, line flip tool.
+	-Geometric validation tools: invalid geometries, duplicate vertices, Z values, angles and vertex density.
+	-Quality Control and Workflow Toolbox with dedicated validation processes.
+	-Attribute validation and Unicode attribute verification.
+	-Access to BDGEx WM(T)S services and to the BDGEx vector/raster product index map.
+	-Inventory Tool for all geospatial data supported by GDAL/OGR.
+	-Hierarchical Snap and polygon construction from lines and centroids.
+	-Drainage network and terrain processing tools, spot elevation extraction and terrain validation.
+	-Tool to install Models and Scripts (geoalgorithms) in the Processing Toolbox (HSV fusion script available).
 	-EDGV code list viewer to aid attributes queries using our EDGV databases.
-	-Drop EDGV databases
-	-Remove missing databases from qsettings
-	-Tool to reclassify features (move them to another layer) with predefined attributes
+	-Tool to reclassify features (move them to another layer) with predefined attributes.
+	-Tool for preparing files for packaging in BDGEx.
 	Requirements for LINUX (Ubuntu/Debian):
 
 	Install the following packages as follows:
-	sudo apt-get install libqt5sql5-psql
 	sudo apt-get install libqt5sql5-sqlite
 
 # End of mandatory metadata

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A versão atual do complemento possui as seguintes funcionalidades:
 - Ferramentas de aquisição com ângulos retos e à mão livre
 - Ferramenta para inverter sentido de linhas (flip)
 - Ferramentas para indicar tamanho da feição durante aquisição
+- Ferramentas de Trim/Extend e de suavização de linhas (Smooth Lines)
 
 ### Validação e Controle de Qualidade
 - Ferramentas de validação geométrica (identificação e correção)
@@ -61,6 +62,7 @@ A versão atual do complemento possui as seguintes funcionalidades:
 - Controle de Qualidade e Workflow Toolbox com ferramentas de validação específicas
 - Identificação de feições fechadas, não unidas, entrelaçadas e próximas
 - Validação de atributos e verificação de atributos Unicode
+- Barra de Revisão para navegação sistemática entre feições pendentes de revisão
 
 ### Integração de Dados
 - Acesso a serviços WM(T)S do BDGEx
@@ -77,6 +79,7 @@ A versão atual do complemento possui as seguintes funcionalidades:
 - Direcionamento de fluxo de drenagens e identificação de inconsistências
 - Ferramentas para extração de pontos cotados e validação do terreno
 - Ferramentas para numeração de polígonos e generalização
+- Processamento de raster: remapeamento de valores, filtro de mediana, rasterização de polígonos com buffer e preparo de imagens para o BDGEx
 
 ### Outros
 - Visualizador de valores de códigos da EDGV para auxiliar em consultas por atributos
@@ -85,10 +88,9 @@ A versão atual do complemento possui as seguintes funcionalidades:
 
 O plugin foi todo desenvolvido em Python e está disponível para download pelo próprio QGIS ou pelo endereço http://plugins.qgis.org/plugins/DsgTools/.
 
-Para acessar o histórico completo de mudanças, visite: https://github.com/dsgoficial/DsgTools/wiki/Changelog-4.3
+Para acessar o histórico completo de mudanças, visite: [CHANGELOG.md](CHANGELOG.md)
 
 Para maiores informações, acesse https://github.com/dsgoficial/DsgTools/wiki ou https://bdgex.eb.mil.br/portal/index.php?option=com_content&view=article&id=96&Itemid=380&lang=pt
-```
 
 ------------------------------------
 # DSGTools Plugin
@@ -103,9 +105,19 @@ This project fulfills the mission established in the Brazilian Army Strategic Pl
 * Initiative 6.3.1.1 - Expand the capability of using digital geoinformation for the Land Force
 * Initiative 6.3.2.1 - Obtain geoinformation production systems using Artificial Intelligence
 
+## Command Line Execution
+
+DSGTools' Processing algorithms can be run **headless, from the command line**
+(without opening QGIS), allowing you to automate workflows and run processings
+in scripts or servers. The list of available algorithms, each one's parameters
+and usage instructions are in the **[`dsgtools_cli/`](dsgtools_cli/)** folder:
+
+- [`dsgtools_cli/README.md`](dsgtools_cli/README.md) — usage guide
+- `python dsgtools_cli/dsgtools_cli.py list` — lists algorithms; `describe <id>` shows its parameters
+
 ## Main Features
 
-The plugin is in version 4.17.27 and has the following features:
+The plugin has the following features:
 
 ### Database Management
 - Database creation using PostGIS according to EDGV 2.1.3, EDGV 3.0, EDGV 3.0 Pro, EDGV 3.0 Orto, and EDGV 3.0 Topo models
@@ -123,6 +135,7 @@ The plugin is in version 4.17.27 and has the following features:
 - Right-angle and freehand acquisition tools
 - Line direction flip tool
 - Tools to indicate feature size during acquisition
+- Trim/Extend and Smooth Lines tools
 
 ### Validation and Quality Control
 - Geometric validation tools (identification and correction)
@@ -130,6 +143,7 @@ The plugin is in version 4.17.27 and has the following features:
 - Quality Control and Workflow Toolbox with specific validation tools
 - Identification of closed, unmerged, intertwined, and nearby features
 - Attribute validation and Unicode attribute verification
+- Review Toolbar for systematic navigation between features pending review
 
 ### Data Integration
 - Access to BDGEx WM(T)S services
@@ -146,6 +160,7 @@ The plugin is in version 4.17.27 and has the following features:
 - Drainage flow direction and inconsistency identification
 - Tools for spot elevation extraction and terrain validation
 - Tools for polygon numbering and generalization
+- Raster processing: value remapping, no-data median filter, rasterize polygons with buffer, and image preparation for BDGEx
 
 
 ### Others
@@ -155,6 +170,6 @@ The plugin is in version 4.17.27 and has the following features:
 
 The plugin was fully developed in Python and is available for download through QGIS or from http://plugins.qgis.org/plugins/DsgTools/.
 
-For the complete changelog, visit: https://github.com/dsgoficial/DsgTools/wiki/Changelog-4.3
+For the complete changelog, visit: [CHANGELOG.md](CHANGELOG.md)
 
 For further information, go to https://github.com/dsgoficial/DsgTools/wiki or https://bdgex.eb.mil.br/portal/index.php?option=com_content&view=article&id=96&Itemid=380&lang=pt


### PR DESCRIPTION
Atualiza `about=` do `metadata.txt` (removidas funcionalidades que não existem mais, removida menção ao dsgtools_cli que não vai pro pacote OSGeo) e revisa `README.md` (bug de markdown, links de changelog desatualizados, funcionalidades faltando). Também muda o checksum do pacote, pra descartar qualquer cache do lado do OSGeo na resubmissão da 5.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)