### PR TITLE
fix: qualifica enums da API do QGIS pro Qt6 (bloqueio 5.2.0 no OSGeo)

### DIFF
--- a/DsgTools/CLAUDE.md
+++ b/DsgTools/CLAUDE.md
@@ -201,7 +201,6 @@ A migração principal é Qt5 → Qt6. O QGIS 4.0 não quebra APIs além do Qt6.
 
 ### ATENTAR: NÃO migrar estes
 
-- `QgsWkbTypes.Point`, `QgsWkbTypes.LineString`, `QgsWkbTypes.Polygon` etc. — são constantes WKB, NÃO enums Qt. Deixar como estão.
 - `QgsProject.instance()` — remoção prevista apenas para QGIS 5.0.
 - `QVariant.Type` — deprecado em 3.38 mas mínimo suportado é 3.22, manter por enquanto.
 
@@ -218,6 +217,37 @@ except ImportError:
 ```
 
 Para enums, preferir a forma fully qualified do Qt6 que já funciona no QGIS 3.40+.
+
+### Enums da própria API do QGIS (não são só os do Qt/PyQt)
+
+**Correção a uma entrada antiga deste arquivo**: chegou a estar documentado aqui que `QgsWkbTypes.Point`, `QgsWkbTypes.LineString` etc. eram "constantes WKB, não enum Qt" e por isso não precisavam ser tocadas. **Isso estava errado** — confirmado por um scanner de compatibilidade Qt6 real (o do repositório de plugins do OSGeo, que reprovou a release 5.2.0 com 718 ocorrências) e testado funcionando em servidor remoto pelo usuário. Além dos enums do Qt/PyQt (tabelas acima), várias classes da própria API do QGIS também passaram a exigir o enum aninhado qualificado no Qt6 — o padrão de acesso direto `Classe.Valor` (que funcionava até QGIS 3.x) agora precisa virar `Classe.EnumAninhado.Valor`. Não são só `QgsWkbTypes` — a lista real (764 ocorrências corrigidas nesta migração, 15+ classes):
+
+| Classe.Valor (Qt5, direto) | Classe.EnumAninhado.Valor (Qt6) |
+|---|---|
+| `QgsWkbTypes.Point`, `.LineString`, `.Polygon`, `.MultiPoint`, etc. | `QgsWkbTypes.Type.*` |
+| `QgsFeatureSink.FastInsert` | `QgsFeatureSink.Flag.FastInsert` |
+| `QgsProcessingParameterNumber.Double` / `.Integer` | `QgsProcessingParameterNumber.Type.*` |
+| `QgsProcessingParameterDefinition.Any` / `.Numeric` / `.String` / `.DateTime` | `QgsProcessingParameterDefinition.DataType.*` |
+| `QgsProcessing.TypeVectorLine` / `.TypeVectorPolygon` / `.TypeVectorAnyGeometry` / `.TypeRaster` / `.TypeFile` / `.TypeVector` / `.TypeVectorPoint` | `QgsProcessing.SourceType.*` |
+| `QgsProcessingParameterFile.Folder` / `.File` | `QgsProcessingParameterFile.Behavior.*` |
+| `QgsCoordinateReferenceSystem.EpsgCrsId` | `QgsCoordinateReferenceSystem.CrsType.EpsgCrsId` |
+| `QgsVectorFileWriter.NoError` | `QgsVectorFileWriter.WriterError.NoError` |
+| `QgsVectorFileWriter.CreateOrOverwriteFile` / `.CreateOrOverwriteLayer` | `QgsVectorFileWriter.ActionOnExistingFile.*` |
+| `QgsDataSourceUri.SslDisable` | `QgsDataSourceUri.SslMode.SslDisable` |
+| `Qgis.DistanceUnit...Meters` | `Qgis.DistanceUnit.*` (idem `Qgis.AreaUnit.*`) |
+| `Qt.ItemDataRole`-like em widgets custom (`LabelRole`, `FieldRole`) | `<Classe>.ItemRole.*` |
+| `Qgis.RelationshipStrength...Association` | `Qgis.RelationshipStrength.*` (mensagem cita `RelationStrength`) |
+| `ProcessManager`-like `.GenericPython` | `.ActionType.GenericPython` |
+| `QFile.WriteOnly` (via `qgis.PyQt.QtCore`) | `QFile.OpenModeFlag.WriteOnly` |
+| ícone customizado tipo `.ICON_X` | `.IconType.ICON_X` |
+
+Essa lista **não é exaustiva por definição** — cada classe da API do QGIS pode ter seu próprio enum aninhado, e o nome do enum (`Type`, `Flag`, `SourceType`, `DataType`, `Behavior`, `CrsType`, `WriterError`, `ActionOnExistingFile`, `SslMode`, `DistanceUnit`, `AreaUnit`, `ItemRole`, `RelationshipStrength`, `ActionType`, `OpenModeFlag`, `IconType`, ...) não segue um padrão previsível — não dá pra adivinhar, só descobrir rodando o scanner de verdade.
+
+**Como corrigir em massa quando aparecer de novo**: o scanner de Qt6-compat do OSGeo (roda quando você tenta publicar uma release) devolve uma tabela `File / Line / Col / Message` no formato `Enum error, add 'X' before 'Y'`, onde `Col` é a coluna 0-indexed do **início da expressão base** (ex.: início de `QgsWkbTypes` em `QgsWkbTypes.LineString`) — não da própria coluna do valor. A correção é mecânica: achar `.{Y}` a partir de `Col` naquela linha e inserir `.{X}` logo antes. Pedir pro usuário salvar o log completo num arquivo (não cola no chat, corta) e escrever um fixer baseado nisso, com verificação de `compile()` por arquivo antes de gravar — foi assim que as 718 ocorrências da 5.2.0 foram corrigidas de uma vez.
+
+Outras duas categorias que apareceram no mesmo scanner, fora do padrão de enum:
+- `"This function should be renamed to 'exec'"` — um método **definido** como `def exec_(self):` (não uma chamada `.exec_()`, essa já é coberta pelo grep de `\.exec_()` acima) precisa virar `def exec(self):`. Conferir antes se algum lugar chama `.exec_()` nessa classe especificamente (senão quebra o caller).
+- `"Invalid conversion of QVariant(QVariant.Null). Use from qgis.core import NULL instead"` — trocar comparação `valor == QVariant()` por `from qgis.core import NULL` + `valor == NULL`.
 
 ## Comandos Úteis
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/abstractConvertDatabaseAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/abstractConvertDatabaseAlgorithm.py
@@ -271,7 +271,7 @@ class AbstractDatabaseAlgorithm(QgsProcessingAlgorithm):
             self.NOT_CONVERTED_POINT,
             context,
             self.fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             outputCrs,
         )
         self.line_flag_sink, self.line_flag_id = self.parameterAsSink(
@@ -279,7 +279,7 @@ class AbstractDatabaseAlgorithm(QgsProcessingAlgorithm):
             self.NOT_CONVERTED_LINE,
             context,
             self.fields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             outputCrs,
         )
         self.poly_flag_sink, self.poly_flag_id = self.parameterAsSink(
@@ -287,16 +287,16 @@ class AbstractDatabaseAlgorithm(QgsProcessingAlgorithm):
             self.NOT_CONVERTED_POLYGON,
             context,
             self.fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             outputCrs,
         )
         self.flagSinkDict = {
-            QgsWkbTypes.Point: self.point_flag_sink,
-            QgsWkbTypes.MultiPoint: self.point_flag_sink,
-            QgsWkbTypes.LineString: self.line_flag_sink,
-            QgsWkbTypes.MultiLineString: self.line_flag_sink,
-            QgsWkbTypes.Polygon: self.poly_flag_sink,
-            QgsWkbTypes.MultiPolygon: self.poly_flag_sink,
+            QgsWkbTypes.Type.Point: self.point_flag_sink,
+            QgsWkbTypes.Type.MultiPoint: self.point_flag_sink,
+            QgsWkbTypes.Type.LineString: self.line_flag_sink,
+            QgsWkbTypes.Type.MultiLineString: self.line_flag_sink,
+            QgsWkbTypes.Type.Polygon: self.poly_flag_sink,
+            QgsWkbTypes.Type.MultiPolygon: self.poly_flag_sink,
         }
 
     def convertFeaturesWithConversionMaps(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/appendFeaturesToLayerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/appendFeaturesToLayerAlgorithm.py
@@ -49,7 +49,7 @@ class AppendFeaturesToLayerAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.LAYER_WITH_FEATURES_TO_APPEND,
                 self.tr("Layer with features to append to original layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -57,7 +57,7 @@ class AppendFeaturesToLayerAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.DESTINATION_LAYER,
                 self.tr("Destination Layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/buildMergedDataAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/buildMergedDataAlgorithm.py
@@ -334,7 +334,7 @@ class BuildMergedDataWithFieldRefactorAlgorithm(ValidationAlgorithm):
             newFeature.setGeometry(feature.geometry())
             for field in fields:
                 newFeature.setAttribute(field.name(), feature[field.name()])
-            sink.addFeature(newFeature, QgsFeatureSink.FastInsert)
+            sink.addFeature(newFeature, QgsFeatureSink.Flag.FastInsert)
             feedback.setProgress(85 + int((current / total) * 10))
 
         feedback.setProgress(95)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/convertDatabaseAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/convertDatabaseAlgorithm.py
@@ -239,7 +239,7 @@ class ConvertDatabasesAlgorithm(AbstractDatabaseAlgorithm):
                 list(
                     map(
                         lambda x: self.flagSinkDict[geomType].addFeature(
-                            self.buildFlagFeat(x), QgsFeatureSink.FastInsert
+                            self.buildFlagFeat(x), QgsFeatureSink.Flag.FastInsert
                         ),
                         featDictList,
                     )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/exportPostGISDataToShapefile.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataManagementAlgs/exportPostGISDataToShapefile.py
@@ -111,7 +111,7 @@ class ExportPostGISDataToShapefile(AbstractDatabaseAlgorithm):
             QgsProcessingParameterFile(
                 self.TEMPLATE_SHAPEFILES_FOLDER,
                 self.tr("Template Shapefiles Folder"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -135,7 +135,7 @@ class ExportPostGISDataToShapefile(AbstractDatabaseAlgorithm):
                 self.GEOGRAPHIC_BOUNDS_NAME_FIELD,
                 self.tr("MI"),
                 parentLayerParameterName=self.GEOGRAPHIC_BOUNDS,
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
             )
         )
         self.addParameter(
@@ -322,7 +322,7 @@ class ExportPostGISDataToShapefile(AbstractDatabaseAlgorithm):
                     list(
                         map(
                             lambda x: self.flagSinkDict[geomType].addFeature(
-                                self.buildFlagFeat(x), QgsFeatureSink.FastInsert
+                                self.buildFlagFeat(x), QgsFeatureSink.Flag.FastInsert
                             ),
                             featDictList,
                         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/cqdgGridGenerator.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/cqdgGridGenerator.py
@@ -221,7 +221,7 @@ class ETCQDGGridGenerator(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_MOLDURA,
                 self.tr("Frame Layer (MI)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -307,7 +307,7 @@ class ETCQDGGridGenerator(QgsProcessingAlgorithm):
             self.OUTPUT_GRID,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             original_crs,
         )
 
@@ -316,7 +316,7 @@ class ETCQDGGridGenerator(QgsProcessingAlgorithm):
             self.OUTPUT_AMOSTRA,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             original_crs,
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/etcqdgSegmentationEvaluator.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/etcqdgSegmentationEvaluator.py
@@ -129,7 +129,7 @@ class ETCQDGSegmentationEvaluator(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_TILES,
                 self.tr("ET-CQDG Tiles Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -137,7 +137,7 @@ class ETCQDGSegmentationEvaluator(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_MASK_LAYER,
                 self.tr("Polygon Layer for Masks"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -146,7 +146,7 @@ class ETCQDGSegmentationEvaluator(QgsProcessingAlgorithm):
                 self.CLASS_FIELD,
                 self.tr("Class Field (integer values)"),
                 parentLayerParameterName=self.INPUT_MASK_LAYER,
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
             )
         )
 
@@ -155,7 +155,7 @@ class ETCQDGSegmentationEvaluator(QgsProcessingAlgorithm):
                 self.CLASS_NAME_FIELD,
                 self.tr("Class Name Field"),
                 parentLayerParameterName=self.INPUT_MASK_LAYER,
-                type=QgsProcessingParameterField.String,
+                type=QgsProcessingParameterField.DataType.String,
                 defaultValue="class_name",
                 optional=True,
             )
@@ -165,7 +165,7 @@ class ETCQDGSegmentationEvaluator(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.SEGMENTATION_RASTER,
                 self.tr("Inferred Masks (Experiment Results)"),
-                QgsProcessing.TypeRaster,
+                QgsProcessing.SourceType.TypeRaster,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/etcqdgSegmentationEvaluatorFromRaster.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/etcqdgSegmentationEvaluatorFromRaster.py
@@ -127,7 +127,7 @@ class ETCQDGSegmentationEvaluatorFromRaster(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_TILES,
                 self.tr("ET-CQDG Tiles Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -142,7 +142,7 @@ class ETCQDGSegmentationEvaluatorFromRaster(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.SEGMENTATION_RASTER,
                 self.tr("Inferred Masks (Experiment Results)"),
-                QgsProcessing.TypeRaster,
+                QgsProcessing.SourceType.TypeRaster,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/pecCalculatorAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/DataQualityAlgs/pecCalculatorAlgorithm.py
@@ -47,14 +47,16 @@ class PecCalculatorAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorPoint]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 self.REFERENCE,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
         self.addParameter(
@@ -62,7 +64,7 @@ class PecCalculatorAlgorithm(QgsProcessingAlgorithm):
                 self.TOLERANCE,
                 self.tr("Max distance"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=2,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/EditingAlgs/createEditingGridAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/EditingAlgs/createEditingGridAlgorithm.py
@@ -56,7 +56,9 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input Layer"), [QgsProcessing.TypeVectorPolygon]
+                self.INPUT,
+                self.tr("Input Layer"),
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -66,7 +68,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.tr("INOM Field"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
 
@@ -76,7 +78,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.tr("ID Field"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
 
@@ -85,7 +87,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.ID_VALUE,
                 self.tr("ID Field Value"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
             )
         )
@@ -95,7 +97,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.CROSSES_X,
                 self.tr("Number of horizontal crosses"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=4,
             )
         )
@@ -105,7 +107,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.CROSSES_Y,
                 self.tr("Number of vertical crosses"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=4,
             )
         )
@@ -115,7 +117,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.SPACING,
                 self.tr("UTM Grid Spacing"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=4000,
             )
         )
@@ -125,7 +127,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.MAP_SCALE,
                 self.tr("Map scale (in thousands)"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=25,
             )
         )
@@ -153,7 +155,7 @@ class CreateEditingGridAlgorithm(QgsProcessingAlgorithm):
                 self.FONT_SIZE,
                 self.tr("Font Size"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=1.5,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/rightAngleToolParametersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/rightAngleToolParametersAlgorithm.py
@@ -46,7 +46,7 @@ class RightAngleToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.MIN_SEGMENT_DISTANCE,
                 self.tr("Minimum Segment Distance"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=2,
             )
         )
@@ -55,7 +55,7 @@ class RightAngleToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.RIGHT_ANGLE_DECIMALS,
                 self.tr("Number of decimal points"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=3,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/setFreeHandToolParametersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/setFreeHandToolParametersAlgorithm.py
@@ -54,7 +54,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.FREE_HAND_TOLERANCE,
                 self.tr("Free hand tolerance"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=2,
             )
         )
@@ -63,7 +63,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.FREE_HAND_SMOOTH_ITERATIONS,
                 self.tr("Free hand smooth iterations"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=3,
             )
         )
@@ -72,7 +72,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.FREE_HAND_SMOOTH_OFFSET,
                 self.tr("Free hand smooth offset"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.25,
             )
         )
@@ -81,7 +81,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.ALG_ITERATIONS,
                 self.tr("Free hand algorithm iterations"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=2,
             )
         )
@@ -90,7 +90,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.UNDO_POINTS,
                 self.tr("Number of points removed on undo action"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=50,
             )
         )
@@ -99,7 +99,7 @@ class SetFreeHandToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.FREE_HAND_FINAL_SIMPLIFY_TOLERANCE,
                 self.tr("Free hand tolerance"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=1,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/smoothLinesToolParametersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/EnvironmentSetterAlgs/smoothLinesToolParametersAlgorithm.py
@@ -47,7 +47,7 @@ class SmoothLinesToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.NUMBER_SMOOTHING_ITERATIONS,
                 self.tr("Smoothing Iterations"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=2,
             )
         )
@@ -57,7 +57,7 @@ class SmoothLinesToolParametersAlgorithm(DsgToolsBaseSetParametersAlgorithm):
                 self.tr("Fraction of line to create new vertices"),
                 minValue=0,
                 maxValue=1,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.30,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/findSmallClosedLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/findSmallClosedLinesAlgorithm.py
@@ -53,7 +53,7 @@ class FindSmallClosedLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeContourLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeContourLinesAlgorithm.py
@@ -28,6 +28,7 @@ from qgis.core import (
     QgsFields,
     QgsGeometry,
     QgsPointXY,
+    NULL,
     QgsProcessing,
     QgsProcessingAlgorithm,
     QgsProcessingException,
@@ -60,7 +61,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input contour lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -69,7 +70,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
                 self.ELEVATION_ATTR,
                 self.tr("Elevation attribute"),
                 parentLayerParameterName=self.INPUT,
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
             )
         )
 
@@ -77,7 +78,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.CONTOUR_INTERVAL,
                 self.tr("Contour interval"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -118,7 +119,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.FRAME,
                 self.tr("Frame layer (clip boundary)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -217,7 +218,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             outFields,
-            QgsWkbTypes.MultiLineString,
+            QgsWkbTypes.Type.MultiLineString,
             sourceCrs,
         )
 
@@ -238,7 +239,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
                 continue
 
             cotaValue = feat[elevAttr]
-            if cotaValue is None or cotaValue == QVariant():
+            if cotaValue is None or cotaValue == NULL:
                 continue
             cotaValue = int(cotaValue)
 
@@ -302,7 +303,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
         # no CRS de origem devolvia graus quando a entrada era geográfica, e como todo
         # anel mede uma fração de grau, todos eram descartados em silêncio.
         toMeters = QgsUnitTypes.fromUnitToUnitFactor(
-            projectedCrs.mapUnits(), QgsUnitTypes.DistanceMeters
+            projectedCrs.mapUnits(), QgsUnitTypes.DistanceUnit.DistanceMeters
         )
 
         for cota, isDepression, geom in mergedLines:
@@ -377,15 +378,15 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
 
             # Ensure MultiLineString output
             if clipped.wkbType() in (
-                QgsWkbTypes.LineString,
-                QgsWkbTypes.LineStringZ,
-                QgsWkbTypes.LineStringM,
-                QgsWkbTypes.LineStringZM,
+                QgsWkbTypes.Type.LineString,
+                QgsWkbTypes.Type.LineStringZ,
+                QgsWkbTypes.Type.LineStringM,
+                QgsWkbTypes.Type.LineStringZM,
             ):
                 clipped = QgsGeometry.collectGeometry([clipped])
             elif clipped.wkbType() in (
-                QgsWkbTypes.GeometryCollection,
-                QgsWkbTypes.GeometryCollectionZ,
+                QgsWkbTypes.Type.GeometryCollection,
+                QgsWkbTypes.Type.GeometryCollectionZ,
             ):
                 # Extract only line parts from geometry collection
                 lineParts = []
@@ -421,7 +422,7 @@ class GeneralizeContourLinesAlgorithm(QgsProcessingAlgorithm):
                         "",  # observacao
                     ]
                 )
-                sink.addFeature(outFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(outFeat, QgsFeatureSink.Flag.FastInsert)
 
             feedback.setProgress(80 + int((i / max(outputCount, 1)) * 20))
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeEdificationsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeEdificationsAlgorithm.py
@@ -48,7 +48,7 @@ class GeneralizeEdificationsAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POINT,
                 self.tr("Point Input Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -74,7 +74,7 @@ class GeneralizeEdificationsAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSink(
                 self.OUTPUT,
                 self.tr("Non-eliminated buildings (nearby high priority)"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
             )
         )
 
@@ -289,7 +289,7 @@ class GeneralizeEdificationsAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             pointLayer.sourceCrs(),
         )
         idsToFlag = set()
@@ -309,7 +309,7 @@ class GeneralizeEdificationsAlgorithm(QgsProcessingAlgorithm):
                         continue
                     newFeat[fieldName] = feat[fieldName]
                 newFeat.setGeometry(feat.geometry())
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
         multiStepFeedback.setProgressText(
             self.tr("Feature addition to sink complete...")
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeEdificationsAreaAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeEdificationsAreaAlgorithm.py
@@ -44,7 +44,7 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POLYGON,
                 self.tr("Polygon Input Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -52,7 +52,7 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POINT,
                 self.tr("Point Input Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -60,7 +60,7 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.ESCALA,
                 self.tr("Scale"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
             )
         )
 
@@ -68,7 +68,7 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.AREAMINIMA,
                 self.tr("Minimum Map Area (degrees squared on chart)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=1,
             )
         )
@@ -104,7 +104,12 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
         crs = ids.sourceCrs()
 
         (polygonSink, polygonSinkId) = self.parameterAsSink(
-            parameters, self.OUTPUTPOLYGON, context, fields, QgsWkbTypes.Polygon, crs
+            parameters,
+            self.OUTPUTPOLYGON,
+            context,
+            fields,
+            QgsWkbTypes.Type.Polygon,
+            crs,
         )
         currentStep += 1
         multiStepFeedback.setCurrentStep(currentStep)
@@ -123,7 +128,7 @@ class GeneralizeEdificationsAreaAlgorithm(QgsProcessingAlgorithm):
         )
         idsToDelete = []
         for feature in selected_features.getFeatures():
-            polygonSink.addFeature(feature, QgsFeatureSink.FastInsert)
+            polygonSink.addFeature(feature, QgsFeatureSink.Flag.FastInsert)
             idsToDelete.append(feature["featid"])
             if multiStepFeedback.isCanceled():
                 return

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeHighwaysAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeHighwaysAlgorithm.py
@@ -43,12 +43,14 @@ class GeneralizeHighwaysAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.NETWORK_LAYER,
                 self.tr("Highway layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterNumber(
-                self.ESCALA, self.tr("Scale"), type=QgsProcessingParameterNumber.Double
+                self.ESCALA,
+                self.tr("Scale"),
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -62,7 +64,7 @@ class GeneralizeHighwaysAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_CONSTRAINT_LAYER_LIST,
                 self.tr("Point constraint Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -70,7 +72,7 @@ class GeneralizeHighwaysAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_CONSTRAINT_LAYER_LIST,
                 self.tr("Line constraint Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -78,7 +80,7 @@ class GeneralizeHighwaysAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGON_CONSTRAINT_LAYER_LIST,
                 self.tr("Polygon constraint Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -86,7 +88,7 @@ class GeneralizeHighwaysAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDS_LAYER,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeLandingStrip.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeLandingStrip.py
@@ -48,7 +48,7 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POLYGON,
                 self.tr("Polygon Input Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -63,7 +63,7 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.AREAMINIMA,
                 self.tr("Minimum Map Area (on chart)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -78,7 +78,7 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
         smooth_voronoi = QgsProcessingParameterNumber(
             self.SVORONOI,
             self.tr("Voronoi smoothing value"),
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
             defaultValue=0.1,
         )
         smooth_voronoi.setFlags(
@@ -89,7 +89,7 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
         smooth_simplify = QgsProcessingParameterNumber(
             self.SSIMPLIFY,
             self.tr("Simplify smoothing value"),
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
             defaultValue=0.0001,
         )
         smooth_simplify.setFlags(
@@ -128,7 +128,12 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
         fields = polygonLayer.fields()
 
         (LineSink, LineSinkId) = self.parameterAsSink(
-            parameters, self.OUTPUTLINE, context, fields, QgsWkbTypes.LineString, crs
+            parameters,
+            self.OUTPUTLINE,
+            context,
+            fields,
+            QgsWkbTypes.Type.LineString,
+            crs,
         )
 
         fields = polygonLayer.fields()
@@ -225,7 +230,7 @@ class GeneralizeLandingStripAlgorithm(QgsProcessingAlgorithm):
                 if fieldName not in fieldsFeat:
                     continue
                 newFeat[fieldName] = feat[fieldName]
-            LineSink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            LineSink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
         polygonLayer.startEditing()
         polygonLayer.beginEditCommand(self.tr("Delete polygons"))
         polygonLayer.deleteFeatures(ids_to_delete)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeNetworkEdgesFromLengthAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeNetworkEdgesFromLengthAlgorithm.py
@@ -67,7 +67,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.NETWORK_LAYER,
                 self.tr("Network layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -75,7 +75,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
                 self.MIN_LENGTH,
                 self.tr("Minimum size"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.001,
             )
         )
@@ -83,7 +83,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_CONSTRAINT_LAYER_LIST,
                 self.tr("Point constraint Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -91,7 +91,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_CONSTRAINT_LAYER_LIST,
                 self.tr("Line constraint Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -99,7 +99,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGON_CONSTRAINT_LAYER_LIST,
                 self.tr("Polygon constraint Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -107,7 +107,7 @@ class GeneralizeNetworkEdgesWithLengthAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDS_LAYER,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeRoundaboutsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeRoundaboutsAlgorithm.py
@@ -38,12 +38,14 @@ class GeneralizeRoundaboutsAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LAYER,
                 self.tr("Highway layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterNumber(
-                self.ESCALA, self.tr("Scale"), type=QgsProcessingParameterNumber.Double
+                self.ESCALA,
+                self.tr("Scale"),
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeWaterBodyAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/generalizeWaterBodyAlgorithm.py
@@ -79,7 +79,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODY,
                 self.tr("Water body (polygon layer)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -117,14 +117,14 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.ISLAND,
                 self.tr("Island (polygon layer)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 self.ISLAND_POINT,
                 self.tr("Island (point layer)"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
         param = QgsProcessingParameterDistance(
@@ -139,7 +139,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.DRAINAGE_LINES,
                 self.tr("Drainage lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         param = QgsProcessingParameterDistance(
@@ -157,7 +157,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
                     "Select field from Drainage Lines to classify outside polygons"
                 ),
                 parentLayerParameterName=self.DRAINAGE_LINES,
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
             )
         )
         self.addParameter(
@@ -176,7 +176,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDS_LAYER,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -184,7 +184,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_CONSTRAINT_LAYER_LIST,
                 self.tr("Point constraint layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -192,7 +192,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_CONSTRAINT_LAYER_LIST,
                 self.tr("Line constraint layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -200,7 +200,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGON_CONSTRAINT_LAYER_LIST,
                 self.tr("Polygon constraint layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -208,14 +208,14 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.DAM,
                 self.tr("Dam lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterFeatureSink(
                 self.OUTPUT_POLYGON,
                 self.tr("Output Removed Polygons"),
-                type=QgsProcessing.TypeVectorPolygon,
+                type=QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
 
@@ -908,14 +908,14 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT_POLYGON,
             context,
             polygon_fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             empty_spaces.crs(),
         )
         for feature in empty_spaces.getFeatures():
             new_feature = QgsFeature(polygon_fields)
             new_feature.setGeometry(feature.geometry())
             new_feature.setAttribute("layer", feature["layer"])
-            polygon_output_sink.addFeature(new_feature, QgsFeatureSink.FastInsert)
+            polygon_output_sink.addFeature(new_feature, QgsFeatureSink.Flag.FastInsert)
 
         self.sink_dict = {
             empty_spaces.id(): polygon_output_sink,
@@ -943,7 +943,7 @@ class GeneralizeWaterBodyAlgorithm(QgsProcessingAlgorithm):
             if feedback is not None and feedback.isCanceled():
                 return
             newFeat = self.createNewFeature(lyr.fields(), feat)
-            sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
             if feedback is not None:
                 feedback.setProgress(current * stepSize)
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/reclassifyAdjacentPolygonsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/reclassifyAdjacentPolygonsAlgorithm.py
@@ -85,7 +85,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_VEGETATION,
                 self.tr("Vegetation Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_vegetacao_a",
             )
         )
@@ -93,7 +93,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_WATER,
                 self.tr("Water Body Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_massa_dagua_a",
             )
         )
@@ -101,7 +101,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_BUILT_UP,
                 self.tr("Built-up Area Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_area_edificada_a",
             )
         )
@@ -109,7 +109,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_FRAME,
                 self.tr("Map Frame"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="aux_moldura_a",
             )
         )
@@ -119,7 +119,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
                 self.tr("Class label field on vegetation layer"),
                 "tipo",
                 self.INPUT_VEGETATION,
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=False,
             )
         )
@@ -127,7 +127,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.WATER_CLASS_VALUE,
                 self.tr("Class value for water bodies"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
             )
         )
@@ -135,7 +135,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.BUILT_UP_CLASS_VALUE,
                 self.tr("Class value for built-up areas"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=2,
             )
         )
@@ -143,7 +143,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.MIN_AREA,
                 self.tr("Default minimum area (m2)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=62500,
                 minValue=0,
             )
@@ -577,7 +577,7 @@ class ReclassifyAdjacentPolygonsAlgorithm(ValidationAlgorithm):
             newFeats.append(newFeat)
 
         if newFeats:
-            lyr.addFeatures(newFeats, QgsFeatureSink.FastInsert)
+            lyr.addFeatures(newFeats, QgsFeatureSink.Flag.FastInsert)
 
         lyr.endEditCommand()
         feedback.pushInfo(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/reclassifyGroupsOfPixelsToNearestNeighborAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/reclassifyGroupsOfPixelsToNearestNeighborAlgorithm.py
@@ -92,7 +92,7 @@ class ReclassifyGroupsOfPixelsToNearestNeighborAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.NODATA_VALUE,
                 self.tr("NODATA pixel value"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=-9999,
             )
         )
@@ -570,7 +570,7 @@ class ReclassifyGroupsOfPixelsToNearestNeighborAlgorithm(ValidationAlgorithm):
                     self.RECLASSIFIED_POLYGONS,
                     context,
                     polygonsNotOnEdge.fields(),
-                    QgsWkbTypes.Polygon,
+                    QgsWkbTypes.Type.Polygon,
                     inputRaster.crs(),
                 )
                 if polygons_sink is not None:
@@ -1130,7 +1130,7 @@ class ReclassifyGroupsOfPixelsToNearestNeighborAlgorithm(ValidationAlgorithm):
             units = crs.mapUnits()
             areaUnit = QgsUnitTypes.distanceToAreaUnit(units)
             conversion_factor = QgsUnitTypes.fromUnitToUnitFactor(
-                areaUnit, QgsUnitTypes.AreaSquareMeters
+                areaUnit, QgsUnitTypes.AreaUnit.AreaSquareMeters
             )
             pixel_area = pixel_width * pixel_height * conversion_factor
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/splitPolygonsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/splitPolygonsAlgorithm.py
@@ -53,7 +53,7 @@ class SplitPolygons(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input polygon layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -70,7 +70,7 @@ class SplitPolygons(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.OVERLAP,
                 self.tr("Overlap value"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.002,
             )
         )
@@ -266,7 +266,7 @@ class SplitPolygons(QgsProcessingAlgorithm):
                     priority += 1
 
         for polygon in final_features.values():
-            sink.addFeature(polygon, QgsFeatureSink.FastInsert)
+            sink.addFeature(polygon, QgsFeatureSink.Flag.FastInsert)
 
         return {self.OUTPUT: dest_id}
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/splitPolygonsByGrid.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeneralizationAlgs/splitPolygonsByGrid.py
@@ -93,7 +93,7 @@ class SplitPolygonsByGrid(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -129,7 +129,7 @@ class SplitPolygonsByGrid(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.NEIGHBOUR,
                 self.tr("Neighbour Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -137,14 +137,14 @@ class SplitPolygonsByGrid(QgsProcessingAlgorithm):
                 self.CLASS_FIELD,
                 self.tr("Class attribute field"),
                 parentLayerParameterName=self.NEIGHBOUR,
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
             )
         )
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.MAX_CONCURRENCY,
                 self.tr("Max Concurrency"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
                 minValue=1,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/donutHoleExtractorAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/donutHoleExtractorAlgorithm.py
@@ -53,7 +53,7 @@ class DonutHoleExtractorAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -126,9 +126,9 @@ class DonutHoleExtractorAlgorithm(ValidationAlgorithm):
                 donutHoleFeatList,
             ) = featureHandler.getFeatureOuterShellAndHoles(feat, isMulti)
             for feat in outerShellFeatList:
-                outershell_sink.addFeature(feat, QgsFeatureSink.FastInsert)
+                outershell_sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
             for feat in donutHoleFeatList:
-                donuthole_sink.addFeature(feat, QgsFeatureSink.FastInsert)
+                donuthole_sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
             # # Update the progress bar
             feedback.setProgress(int(current * total))
         return {self.DONUTHOLE: donuthole_dest_id, self.OUTERSHELL: outershell_dest_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractByDE9IM.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractByDE9IM.py
@@ -66,7 +66,7 @@ class ExtractByDE9IMAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Select features from"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -74,7 +74,7 @@ class ExtractByDE9IMAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INTERSECT,
                 self.tr("By comparing features from"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractElevationPoints.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractElevationPoints.py
@@ -93,7 +93,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.CONTOUR_LINES,
                 self.tr("Contour Lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_curva_nivel_l",
             )
         )
@@ -104,7 +104,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
                 self.tr("Contour value field"),
                 "cota",
                 self.CONTOUR_LINES,
-                QgsProcessingParameterField.Numeric,
+                QgsProcessingParameterField.DataType.Numeric,
             )
         )
 
@@ -131,7 +131,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic bounds layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
                 defaultValue="aux_moldura_a",
             )
@@ -187,7 +187,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODIES,
                 self.tr("Water Bodies"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_massa_dagua_a",
             )
         )
@@ -196,7 +196,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.AREA_WITHOUT_INFORMATION_POLYGONS,
                 self.tr("Area without information layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -205,7 +205,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.DRAINAGE_LINES,
                 self.tr("Drainage lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_trecho_drenagem_l",
             )
         )
@@ -216,7 +216,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
                 self.tr("Drainage name field"),
                 "nome",
                 self.DRAINAGE_LINES,
-                QgsProcessingParameterField.String,
+                QgsProcessingParameterField.DataType.String,
             )
         )
 
@@ -232,7 +232,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.ROADS,
                 self.tr("Roads"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="infra_via_deslocamento_l",
             )
         )
@@ -358,7 +358,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             self.outputCrs,
         )
         layerHandler = LayerHandler()
@@ -545,7 +545,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList = self.dropContourIntervalMultiples(
                 featList, contourHeightInterval, feedback=multiStepFeedback
             )
-            self.sink.addFeatures(featList, QgsFeatureSink.FastInsert)
+            self.sink.addFeatures(featList, QgsFeatureSink.Flag.FastInsert)
         return {
             "OUTPUT": self.sink_id,
         }
@@ -767,7 +767,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList=minMaxFeats,
             fields=fields,
             crs=clippedRasterLyr.crs(),
-            wkbType=QgsWkbTypes.Point,
+            wkbType=QgsWkbTypes.Type.Point,
             context=context,
         )
         # compute number of points
@@ -1811,7 +1811,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
                 featList=maxFeatList,
                 fields=fields,
                 crs=crs,
-                wkbType=QgsWkbTypes.Point,
+                wkbType=QgsWkbTypes.Type.Point,
                 context=QgsProcessingContext(),
             )
             filteredFeatureList = self.filterFeaturesByDistanceAndExclusionLayer(
@@ -1850,7 +1850,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList=list(featSet),
             fields=fields,
             crs=crs,
-            wkbType=QgsWkbTypes.Point,
+            wkbType=QgsWkbTypes.Type.Point,
             context=context,
         )
         filteredPoints = self.filterFeaturesByDistanceAndExclusionLayer(
@@ -1903,7 +1903,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
                 featList=minFeatList,
                 fields=fields,
                 crs=crs,
-                wkbType=QgsWkbTypes.Point,
+                wkbType=QgsWkbTypes.Type.Point,
                 context=QgsProcessingContext(),
             )
             filteredFeatureList = self.filterFeaturesByDistanceAndExclusionLayer(
@@ -1939,7 +1939,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList=minFeatList,
             fields=fields,
             crs=crs,
-            wkbType=QgsWkbTypes.Point,
+            wkbType=QgsWkbTypes.Type.Point,
             context=context,
         )
         filteredPoints = self.filterFeaturesByDistanceAndExclusionLayer(
@@ -1979,7 +1979,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList=inputPointList,
             fields=fields,
             crs=referenceLyr.crs(),
-            wkbType=QgsWkbTypes.Point,
+            wkbType=QgsWkbTypes.Type.Point,
             context=context,
         )
         pointList = self.filterFeaturesByDistanceAndExclusionLayer(
@@ -2009,7 +2009,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
             featList=pointList,
             fields=fields,
             crs=referenceLyr.crs(),
-            wkbType=QgsWkbTypes.Point,
+            wkbType=QgsWkbTypes.Type.Point,
             context=context,
         )
         return self.filterPointsAgainstGrid(
@@ -2748,7 +2748,7 @@ class ExtractElevationPoints(QgsProcessingAlgorithm):
                 featList=newFeatList,
                 fields=fields,
                 crs=rasterLyr.crs(),
-                wkbType=QgsWkbTypes.Point,
+                wkbType=QgsWkbTypes.Type.Point,
                 context=context,
             )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractMiddleVertexOnLineAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/extractMiddleVertexOnLineAlgorithm.py
@@ -47,7 +47,7 @@ class ExtractMiddleVertexOnLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input Line Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -73,7 +73,7 @@ class ExtractMiddleVertexOnLineAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             outputFields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             inputSource.sourceCrs(),
         )
         if output_sink is None:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/line2Multiline.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/line2Multiline.py
@@ -86,7 +86,7 @@ class Line2Multiline(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Select line layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -106,7 +106,7 @@ class Line2Multiline(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            QgsWkbTypes.MultiLineString,
+            QgsWkbTypes.Type.MultiLineString,
             source.sourceCrs(),
         )
 
@@ -189,7 +189,7 @@ class Line2Multiline(QgsProcessingAlgorithm):
             new_feat = QgsFeature(fields)
             new_feat.setGeometry(out_geom)
             new_feat["length"] = out_geom.length()
-            sink.addFeature(new_feat, QgsFeatureSink.FastInsert)
+            sink.addFeature(new_feat, QgsFeatureSink.Flag.FastInsert)
 
             multi_feedback.setProgress(current * step_size)
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/lineOnAreaOverlayer.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/lineOnAreaOverlayer.py
@@ -52,7 +52,7 @@ class LineOnAreaOverlayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_POLYGONS,
                 self.tr("Input polygon layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -61,7 +61,7 @@ class LineOnAreaOverlayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.OVERLAY_LINES,
                 self.tr("Overlay line layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -72,7 +72,7 @@ class LineOnAreaOverlayerAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT_POLYGONS",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -299,7 +299,7 @@ class LineOnAreaOverlayerAlgorithm(QgsProcessingAlgorithm):
             for field in outputFields:
                 newFeat[field.name()] = feat[field.name()]
             newFeat.setGeometry(feat.geometry())
-            output_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            output_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
         list(map(outputFeature, final_result_lyr.getFeatures()))
         return {self.OUTPUT: output_dest_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/lineOnLineOverlayerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/lineOnLineOverlayerAlgorithm.py
@@ -58,7 +58,7 @@ class LineOnLineOverlayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input line layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -67,7 +67,7 @@ class LineOnLineOverlayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.REFERENCE_LINES,
                 self.tr("Reference line layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -76,7 +76,7 @@ class LineOnLineOverlayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SNAP_TOLERANCE,
                 self.tr("Snap tolerance for vertex insertion"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.001,
                 minValue=0.0,
                 optional=True,
@@ -171,7 +171,7 @@ class LineOnLineOverlayerAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT_MODIFIED_REFERENCES,
             context,
             outputFields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             input_line_source.sourceCrs(),
         )
         current_step += 1
@@ -308,11 +308,11 @@ class LineOnLineOverlayerAlgorithm(QgsProcessingAlgorithm):
 
         # Function to output split line features with filtered attributes
         def outputSplitLineFeature(feat):
-            split_lines_sink.addFeature(feat, QgsFeatureSink.FastInsert)
+            split_lines_sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
         # Function to output modified reference line features
         def outputModifiedReferenceFeature(feat):
-            modified_refs_sink.addFeature(feat, QgsFeatureSink.FastInsert)
+            modified_refs_sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
         # Write split input lines to output
         list(map(outputSplitLineFeature, cleaned_split_lines.getFeatures()))

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/numberPolygons.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/numberPolygons.py
@@ -41,7 +41,7 @@ class NumberPolygonsAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LAYER,
                 self.tr("Input polygon layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -129,7 +129,7 @@ class NumberPolygonsAlgorithm(QgsProcessingAlgorithm):
             new_feature = QgsFeature(fields)
             new_feature.setGeometry(feature.geometry())
             new_feature.setAttributes(feature.attributes() + [i])
-            sink.addFeature(new_feature, QgsFeatureSink.FastInsert)
+            sink.addFeature(new_feature, QgsFeatureSink.Flag.FastInsert)
             feedback.setProgress(int(i * total))
 
         return {self.OUTPUT_LAYER: dest_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/nurbfitSmoothingAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/nurbfitSmoothingAlgorithm.py
@@ -40,7 +40,7 @@ class NURBFitSmoothingAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -48,7 +48,7 @@ class NURBFitSmoothingAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.DEGREE,
                 self.tr("Degree of basis polynomial"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 minValue=2,
                 defaultValue=3,
             )
@@ -58,7 +58,7 @@ class NURBFitSmoothingAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SMOOTHING_FACTOR,
                 self.tr("Smoothing factor (0 = interpolation only)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=1.0,
             )
@@ -68,7 +68,7 @@ class NURBFitSmoothingAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SEGMENT_LENGTH,
                 self.tr("Segment length (0 = automatic)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=0,
             )
@@ -126,7 +126,7 @@ class NURBFitSmoothingAlgorithm(QgsProcessingAlgorithm):
                 out_feature = QgsFeature()
                 out_feature.setGeometry(smoothed_geom)
                 out_feature.setAttributes(feature.attributes())
-                sink.addFeature(out_feature, QgsFeatureSink.FastInsert)
+                sink.addFeature(out_feature, QgsFeatureSink.Flag.FastInsert)
 
             feedback.setProgress(int(current * total))
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/optimalTileBBoxAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/optimalTileBBoxAlgorithm.py
@@ -209,7 +209,7 @@ class OptimalTileBBoxAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_TILES,
                 self.tr("Tile layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -222,7 +222,7 @@ class OptimalTileBBoxAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.COVERAGE_THRESH,
                 self.tr("Minimum coverage for rectangle merging (%)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=85.0,
                 minValue=0.0,
                 maxValue=100.0,
@@ -232,7 +232,7 @@ class OptimalTileBBoxAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MAX_WORKERS,
                 self.tr("Parallel workers"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=4,
                 minValue=1,
                 maxValue=32,
@@ -365,7 +365,7 @@ class OptimalTileBBoxAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT_BBOXES,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             layer.crs(),
         )
 
@@ -384,7 +384,7 @@ class OptimalTileBBoxAlgorithm(QgsProcessingAlgorithm):
             feat["rect_id"] = i
             feat["coverage_pct"] = round(rect["coverage_pct"], 2)
             feat["tile_count"] = rect["tile_count"]
-            sink.addFeature(feat, QgsFeatureSink.FastInsert)
+            sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
         feedback.setProgress(100)
         return {self.OUTPUT_BBOXES: dest_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/polygonTiler.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/polygonTiler.py
@@ -121,7 +121,9 @@ class PolygonTilerAlgorithm(QgsProcessingAlgorithm):
         # Add the input vector layer parameter
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorPolygon]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -165,7 +167,7 @@ class PolygonTilerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.OVERLAP_X,
                 self.tr("X overlap (map units for fixed size, % for grid)"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 0.0,  # Default value (no overlap)
                 True,  # Optional
                 0.0,  # Minimum value
@@ -178,7 +180,7 @@ class PolygonTilerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.OVERLAP_Y,
                 self.tr("Y overlap (map units for fixed size, % for grid)"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 0.0,  # Default value (no overlap)
                 True,  # Optional
                 0.0,  # Minimum value
@@ -233,7 +235,7 @@ class PolygonTilerAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             self.fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             source.sourceCrs(),
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/selectByDE9IM.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/selectByDE9IM.py
@@ -66,7 +66,7 @@ class SelectByDE9IMAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Select features from"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -74,7 +74,7 @@ class SelectByDE9IMAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INTERSECT,
                 self.tr("By comparing features from"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/setLineOrientation.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/setLineOrientation.py
@@ -52,7 +52,7 @@ class SetLineOrientation(QgsProcessingAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(
             QgsProcessingParameterFeatureSource(
-                self.INPUT, self.tr("Input"), [QgsProcessing.TypeVectorLine]
+                self.INPUT, self.tr("Input"), [QgsProcessing.SourceType.TypeVectorLine]
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/smallHoleRemoverAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/smallHoleRemoverAlgorithm.py
@@ -58,7 +58,7 @@ class SmallHoleRemoverAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -80,7 +80,7 @@ class SmallHoleRemoverAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to consider on dissolve"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -91,7 +91,7 @@ class SmallHoleRemoverAlgorithm(ValidationAlgorithm):
                 self.tr("Max hole area to eliminate"),
                 defaultValue=15625,
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/splitLinesAtMaximumLengthAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/GeometricAlgs/splitLinesAtMaximumLengthAlgorithm.py
@@ -54,7 +54,9 @@ class SplitLinesAtMaximumLengthAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterFeatureSource(
-                self.INPUT, self.tr("Input line layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input line layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         param = QgsProcessingParameterDistance(
@@ -107,7 +109,7 @@ class SplitLinesAtMaximumLengthAlgorithm(QgsProcessingAlgorithm):
         )
         currentStep += 1
         multiStepFeedback.setCurrentStep(currentStep)
-        sinkLambda = lambda x: sink.addFeature(x, QgsFeatureSink.FastInsert)
+        sinkLambda = lambda x: sink.addFeature(x, QgsFeatureSink.Flag.FastInsert)
 
         if open_lines.featureCount() > 0:
             feedback.pushInfo(
@@ -168,7 +170,7 @@ class SplitLinesAtMaximumLengthAlgorithm(QgsProcessingAlgorithm):
                         else geom.asPolyline()
                     )
                     if len(vertices) < 4:
-                        sink.addFeature(feature, QgsFeatureSink.FastInsert)
+                        sink.addFeature(feature, QgsFeatureSink.Flag.FastInsert)
                         continue
 
                     # Split at approximately midway point
@@ -184,12 +186,12 @@ class SplitLinesAtMaximumLengthAlgorithm(QgsProcessingAlgorithm):
                     feat1 = QgsFeature(feature.fields())
                     feat1.setAttributes(feature.attributes())
                     feat1.setGeometry(QgsGeometry.fromPolylineXY(part1))
-                    sink.addFeature(feat1, QgsFeatureSink.FastInsert)
+                    sink.addFeature(feat1, QgsFeatureSink.Flag.FastInsert)
 
                     feat2 = QgsFeature(feature.fields())
                     feat2.setAttributes(feature.attributes())
                     feat2.setGeometry(QgsGeometry.fromPolylineXY(part2))
-                    sink.addFeature(feat2, QgsFeatureSink.FastInsert)
+                    sink.addFeature(feat2, QgsFeatureSink.Flag.FastInsert)
 
         return {self.OUTPUT: dest_id}
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/applyStylesFromDatabaseToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/applyStylesFromDatabaseToLayersAlgorithm.py
@@ -45,7 +45,7 @@ class ApplyStylesFromDatabaseToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignActionsToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignActionsToLayersAlgorithm.py
@@ -49,7 +49,7 @@ class AssignActionsToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignAliasesToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignAliasesToLayersAlgorithm.py
@@ -57,7 +57,7 @@ class AssignAliasesToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignBoundingBoxFilterToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignBoundingBoxFilterToLayersAlgorithm.py
@@ -48,7 +48,7 @@ class AssignBoundingBoxFilterToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignConditionalStyleToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignConditionalStyleToLayersAlgorithm.py
@@ -50,7 +50,7 @@ class AssignConditionalStyleToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignDefaultFieldValueToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignDefaultFieldValueToLayersAlgorithm.py
@@ -48,7 +48,7 @@ class AssignDefaultFieldValueToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignExpressionFieldToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignExpressionFieldToLayersAlgorithm.py
@@ -50,7 +50,7 @@ class AssignExpressionFieldToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignFilterToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignFilterToLayersAlgorithm.py
@@ -47,7 +47,7 @@ class AssignFilterToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignFormatRulesToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignFormatRulesToLayersAlgorithm.py
@@ -68,7 +68,7 @@ class AssignFormatRulesToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.FILE,
                 description=self.tr("JSON File with rules"),
-                behavior=QgsProcessingParameterFile.File,
+                behavior=QgsProcessingParameterFile.Behavior.File,
                 fileFilter="JSON (*.json)",
                 optional=True,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignMeasureColumnToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignMeasureColumnToLayersAlgorithm.py
@@ -44,7 +44,7 @@ class AssignMeasureColumnToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignValueMapToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/assignValueMapToLayersAlgorithm.py
@@ -45,7 +45,7 @@ class AssignValueMapToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/buildJoinsOnLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/buildJoinsOnLayersAlgorithm.py
@@ -54,7 +54,9 @@ class BuildJoinsOnLayersAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
-                self.INPUT_LAYERS, self.tr("Input Layers"), QgsProcessing.TypeVector
+                self.INPUT_LAYERS,
+                self.tr("Input Layers"),
+                QgsProcessing.SourceType.TypeVector,
             )
         )
         self.addParameter(
@@ -82,7 +84,7 @@ class BuildJoinsOnLayersAlgorithm(QgsProcessingAlgorithm):
         ):
             if feedback.isCanceled():
                 break
-            if relation.strength() != QgsRelation.Association:
+            if relation.strength() != QgsRelation.RelationStrength.Association:
                 continue
             originalLyr = relation.referencingLayer()
             joinnedLyr = relation.referencedLayer()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/buildZipPackagesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/buildZipPackagesAlgorithm.py
@@ -47,7 +47,7 @@ class BuildZipPackageAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.INPUT_SHAPEFILE_FOLDER,
                 self.tr("Folder with Shapefiles"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -65,7 +65,7 @@ class BuildZipPackageAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.OUTPUT_ZIP_FOLDER,
                 self.tr("Destination folder"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/groupLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/groupLayersAlgorithm.py
@@ -59,7 +59,9 @@ class GroupLayersAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
-                self.INPUT_LAYERS, self.tr("Input Layers"), QgsProcessing.TypeVector
+                self.INPUT_LAYERS,
+                self.tr("Input Layers"),
+                QgsProcessing.SourceType.TypeVector,
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/loadRasterLayerFromServerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/loadRasterLayerFromServerAlgorithm.py
@@ -135,7 +135,7 @@ class LoadRasterLayerFromServerAlgorithm(QgsProcessingAlgorithm):
             db_name,
             user,
             password,
-            sslmode=QgsDataSourceUri.SslDisable,
+            sslmode=QgsDataSourceUri.SslMode.SslDisable,
         )
         serverDict = self.connectToServerDict(
             server_ip, port, db_name, user, password, table_name

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/loadShapefileAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/loadShapefileAlgorithm.py
@@ -49,7 +49,7 @@ class LoadShapefileAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.FOLDER_SHAPEFILES,
                 self.tr("Folder with Shapefiles"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/lockAttributeEditingAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/lockAttributeEditingAlgorithm.py
@@ -45,7 +45,7 @@ class LockAttributeEditingAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/matchAndApplyQmlStylesToLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/matchAndApplyQmlStylesToLayersAlgorithm.py
@@ -48,7 +48,7 @@ class MatchAndApplyQmlStylesToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 
@@ -56,7 +56,7 @@ class MatchAndApplyQmlStylesToLayersAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.QML_FOLDER,
                 self.tr("Input QML Folder"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
                 defaultValue="/path/to/qmlFolder",
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/mergeShapefileZipFilesInSingleGeopackage.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/mergeShapefileZipFilesInSingleGeopackage.py
@@ -102,7 +102,9 @@ class MergeShapefileZipFilesInSingleGeopackage(QgsProcessingAlgorithm):
         # Input: Multiple zip files
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
-                self.INPUT_ZIPS, self.tr("Input ZIP files"), QgsProcessing.TypeFile
+                self.INPUT_ZIPS,
+                self.tr("Input ZIP files"),
+                QgsProcessing.SourceType.TypeFile,
             )
         )
 
@@ -271,9 +273,9 @@ class MergeShapefileZipFilesInSingleGeopackage(QgsProcessingAlgorithm):
             save_options.driverName = "GPKG"
             save_options.layerName = output_layer_name
             save_options.actionOnExistingFile = (
-                QgsVectorFileWriter.CreateOrOverwriteFile
+                QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteFile
                 if consolidated_count == 0
-                else QgsVectorFileWriter.CreateOrOverwriteLayer
+                else QgsVectorFileWriter.ActionOnExistingFile.CreateOrOverwriteLayer
             )
 
             # Write to GeoPackage
@@ -289,7 +291,7 @@ class MergeShapefileZipFilesInSingleGeopackage(QgsProcessingAlgorithm):
                 source_layer, output_gpkg, save_options
             )
 
-            if error != QgsVectorFileWriter.NoError:
+            if error != QgsVectorFileWriter.WriterError.NoError:
                 raise QgsProcessingException(
                     self.tr("Error writing layer {0} to GeoPackage: {1}").format(
                         output_layer_name, error_message

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/setRemoveDuplicateNodePropertyOnLayers.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/LayerManagementAlgs/setRemoveDuplicateNodePropertyOnLayers.py
@@ -41,7 +41,7 @@ class SetRemoveDuplicateNodePropertyOnLayers(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/azimuthCalculationAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/azimuthCalculationAlgorithm.py
@@ -44,7 +44,10 @@ class AzimuthCalculationAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LAYER,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/batchRunAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/batchRunAlgorithm.py
@@ -121,7 +121,7 @@ class BatchRunAlgorithm(QgsProcessingAlgorithm):
                 self.OUTPUT,
                 context,
                 self.flagFields,
-                QgsWkbTypes.Point,
+                QgsWkbTypes.Type.Point,
                 QgsProject.instance().crs(),
             )
             gc.enable()
@@ -186,7 +186,7 @@ class BatchRunAlgorithm(QgsProcessingAlgorithm):
                 self.OUTPUT,
                 context,
                 self.flagFields,
-                QgsWkbTypes.Point,
+                QgsWkbTypes.Type.Point,
                 QgsProject.instance().crs(),
             )
         gc.enable()
@@ -237,7 +237,7 @@ class BatchRunAlgorithm(QgsProcessingAlgorithm):
             newFeat["alg_name"] = algName
             newFeat["layer_name"] = inputLyrName
             newFeat.setGeometry(feat.geometry())
-            self.flagSink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            self.flagSink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def prepareFlagSink(self, parameters, flagSource, context):
         for field in flagSource.fields():

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/batchRunAlgorithmWithGeographicBoundsConstraint.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/batchRunAlgorithmWithGeographicBoundsConstraint.py
@@ -86,7 +86,7 @@ class BatchRunAlgorithmWithGeographicBoundsConstraint(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -162,7 +162,7 @@ class BatchRunAlgorithmWithGeographicBoundsConstraint(QgsProcessingAlgorithm):
                 self.OUTPUT,
                 context,
                 self.flagFields,
-                QgsWkbTypes.Point,
+                QgsWkbTypes.Type.Point,
                 QgsProject.instance().crs(),
             )
             gc.enable()
@@ -239,7 +239,7 @@ class BatchRunAlgorithmWithGeographicBoundsConstraint(QgsProcessingAlgorithm):
                 self.OUTPUT,
                 context,
                 self.flagFields,
-                QgsWkbTypes.Point,
+                QgsWkbTypes.Type.Point,
                 QgsProject.instance().crs(),
             )
         gc.enable()
@@ -312,7 +312,7 @@ class BatchRunAlgorithmWithGeographicBoundsConstraint(QgsProcessingAlgorithm):
             newFeat["alg_name"] = algName
             newFeat["layer_name"] = inputLyrName
             newFeat.setGeometry(feat.geometry())
-            self.flagSink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            self.flagSink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def prepareFlagSink(self, parameters, flagSource, context):
         for field in flagSource.fields():

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/convertLayer2LayerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/convertLayer2LayerAlgorithm.py
@@ -50,7 +50,7 @@ class ConvertLayer2LayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -65,7 +65,7 @@ class ConvertLayer2LayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.FILTER_LAYER,
                 self.tr("Filter layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -107,7 +107,7 @@ class ConvertLayer2LayerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.OUTPUT,
                 self.tr("Output layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createFrameAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createFrameAlgorithm.py
@@ -106,7 +106,7 @@ class CreateFrameAlgorithm(QgsProcessingAlgorithm):
             self.XSUBDIVISIONS,
             self.tr("Number of subdivisions on x-axis"),
             minValue=1,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
             optional=True,
         )
         param.setFlags(
@@ -119,7 +119,7 @@ class CreateFrameAlgorithm(QgsProcessingAlgorithm):
             self.YSUBDIVISIONS,
             self.tr("Number of subdivisions on y-axis"),
             minValue=1,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
             optional=True,
         )
         param.setFlags(
@@ -201,7 +201,7 @@ class CreateFrameAlgorithm(QgsProcessingAlgorithm):
         fields.append(QgsField("inom", QMetaType.Type.QString))
         fields.append(QgsField("mi", QMetaType.Type.QString))
         (output_sink, output_sink_id) = self.parameterAsSink(
-            parameters, self.OUTPUT, context, fields, QgsWkbTypes.Polygon, crs
+            parameters, self.OUTPUT, context, fields, QgsWkbTypes.Type.Polygon, crs
         )
 
         featureList = []
@@ -238,7 +238,7 @@ class CreateFrameAlgorithm(QgsProcessingAlgorithm):
         for feat in featureList:
             if feedback.isCanceled():
                 break
-            output_sink.addFeature(feat, QgsFeatureSink.FastInsert)
+            output_sink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
         return {"OUTPUT": output_sink_id}
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createFramesWithConstraintAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createFramesWithConstraintAlgorithm.py
@@ -92,7 +92,7 @@ class CreateFramesWithConstraintAlgorithm(QgsProcessingAlgorithm):
             self.XSUBDIVISIONS,
             self.tr("Number of subdivisions on x-axis"),
             minValue=1,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
             optional=True,
         )
         param.setFlags(
@@ -105,7 +105,7 @@ class CreateFramesWithConstraintAlgorithm(QgsProcessingAlgorithm):
             self.YSUBDIVISIONS,
             self.tr("Number of subdivisions on y-axis"),
             minValue=1,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
             optional=True,
         )
         param.setFlags(
@@ -193,7 +193,7 @@ class CreateFramesWithConstraintAlgorithm(QgsProcessingAlgorithm):
             ySubdivisions = default_y
 
         (output_sink, output_sink_id) = self.parameterAsSink(
-            parameters, self.OUTPUT, context, fields, QgsWkbTypes.Polygon, crs
+            parameters, self.OUTPUT, context, fields, QgsWkbTypes.Type.Polygon, crs
         )
         featureList = []
         coordinateTransformer = QgsCoordinateTransform(
@@ -240,14 +240,14 @@ class CreateFramesWithConstraintAlgorithm(QgsProcessingAlgorithm):
         if needsFiltering:
             list(
                 map(
-                    lambda x: output_sink.addFeature(x, QgsFeatureSink.FastInsert),
+                    lambda x: output_sink.addFeature(x, QgsFeatureSink.Flag.FastInsert),
                     filter(filterFunc, featureList),
                 )
             )
         else:
             list(
                 map(
-                    lambda x: output_sink.addFeature(x, QgsFeatureSink.FastInsert),
+                    lambda x: output_sink.addFeature(x, QgsFeatureSink.Flag.FastInsert),
                     featureList,
                 )
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createGridAlongLineAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createGridAlongLineAlgorithm.py
@@ -61,7 +61,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_LAYER,
                 self.tr("Insert the line layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -87,7 +87,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.OVERLAP,
                 self.tr("Overlap (%)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 maxValue=100,
                 defaultValue=10,
@@ -98,7 +98,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.START,
                 self.tr("Start from begin (m)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=50,
             )
         )
@@ -106,7 +106,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MARGINS_TOP,
                 self.tr("Top Margin (mm)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -116,7 +116,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MARGINS_BOTTOM,
                 self.tr("Bottom Margin (mm)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -126,7 +126,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MARGINS_LEFT,
                 self.tr("Left Margin (mm)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -136,7 +136,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MARGINS_RIGHT,
                 self.tr("Right Margin (mm)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -144,7 +144,9 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
 
         self.addParameter(
             QgsProcessingParameterFeatureSink(
-                self.OUTPUT, self.tr("Grid Layer"), QgsProcessing.TypeVectorPolygon
+                self.OUTPUT,
+                self.tr("Grid Layer"),
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
 
@@ -192,7 +194,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             source.sourceCrs(),
         )
 
@@ -234,7 +236,7 @@ class CreateGridAlongLineAlgorithm(QgsProcessingAlgorithm):
                 )
                 curs = curs + stepnudge
                 new_feat = self.createFeature(r, line_id, geom)
-                sink.addFeature(new_feat, QgsFeatureSink.FastInsert)
+                sink.addFeature(new_feat, QgsFeatureSink.Flag.FastInsert)
                 r += 1
 
             feedback.setProgress(current * stepSize)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createGridFromCoordinatesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createGridFromCoordinatesAlgorithm.py
@@ -56,7 +56,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.X_MIN,
                 self.tr("Min x coordinates"),
                 defaultValue=0.005,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -65,7 +65,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.Y_MIN,
                 self.tr("Min y coordinates"),
                 defaultValue=0.005,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -74,7 +74,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.X_MAX,
                 self.tr("Max x coordinates"),
                 defaultValue=0.005,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -83,7 +83,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.Y_MAX,
                 self.tr("Max y coordinates"),
                 defaultValue=0.005,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -93,7 +93,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Number of subdivisions on x"),
                 defaultValue=2,
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
             )
         )
 
@@ -103,7 +103,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Number of subdivisions on y"),
                 defaultValue=2,
                 minValue=1,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
             )
         )
 
@@ -136,7 +136,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             QgsFields(),
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             crs,
         )
         multiStepFeedback = QgsProcessingMultiStepFeedback(5, feedback)
@@ -153,7 +153,7 @@ class CreateGridFromCoordinatesAlgorithm(QgsProcessingAlgorithm):
         )
         list(
             map(
-                lambda x: output_sink.addFeature(x, QgsFeatureSink.FastInsert),
+                lambda x: output_sink.addFeature(x, QgsFeatureSink.Flag.FastInsert),
                 grid.getFeatures(),
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createReviewGridAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/createReviewGridAlgorithm.py
@@ -58,7 +58,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
             )
         )
@@ -69,7 +69,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Grid size on x-axis"),
                 defaultValue=0.005,
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -79,7 +79,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
                 self.tr("Grid size on y-axis"),
                 defaultValue=0.005,
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 
@@ -88,7 +88,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
             self.RELATED_TASK_ID,
             self.tr("Related task id"),
             optional=True,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
         )
         paramRelatedTask.setFlags(
             paramRelatedTask.flags()
@@ -100,7 +100,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
             self.UNIT_WORK_ID,
             self.tr("Work unit id"),
             optional=True,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
         )
         paramUnitWork.setFlags(
             paramUnitWork.flags() | QgsProcessingParameterDefinition.Flag.FlagAdvanced
@@ -111,7 +111,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
             self.STEP_ID,
             self.tr("Step id"),
             optional=True,
-            type=QgsProcessingParameterNumber.Integer,
+            type=QgsProcessingParameterNumber.Type.Integer,
         )
         paramStep.setFlags(
             paramStep.flags() | QgsProcessingParameterDefinition.Flag.FlagAdvanced
@@ -143,7 +143,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             inputSource.sourceCrs(),
         )
         multiStepFeedback = QgsProcessingMultiStepFeedback(5, feedback)
@@ -177,7 +177,7 @@ class CreateReviewGridAlgorithm(QgsProcessingAlgorithm):
         multiStepFeedback.setCurrentStep(4)
         list(
             map(
-                lambda x: output_sink.addFeature(x, QgsFeatureSink.FastInsert),
+                lambda x: output_sink.addFeature(x, QgsFeatureSink.Flag.FastInsert),
                 sortedFeatures,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/exportFeaturesByAttributeAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/exportFeaturesByAttributeAlgorithm.py
@@ -66,7 +66,9 @@ class ExportFeaturesByAttributeAlgorithm(QgsProcessingAlgorithm):
         """Initializes algorithm parameters."""
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVector]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVector],
             )
         )
 
@@ -110,7 +112,7 @@ class ExportFeaturesByAttributeAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             fields,
-            layer.wkbType() if layer else QgsWkbTypes.NoGeometry,
+            layer.wkbType() if layer else QgsWkbTypes.Type.NoGeometry,
             layer.sourceCrs() if layer else None,
         )
 
@@ -162,7 +164,7 @@ class ExportFeaturesByAttributeAlgorithm(QgsProcessingAlgorithm):
         for current, feature in enumerate(matched_features):
             if feedback.isCanceled():
                 break
-            sink.addFeature(feature, QgsFeatureSink.FastInsert)
+            sink.addFeature(feature, QgsFeatureSink.Flag.FastInsert)
             feedback.setProgress(int((current / nFeatures) * 100))
 
         feedback.pushInfo(self.tr("Export completed successfully."))

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/fileInventoryAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/fileInventoryAlgorithm.py
@@ -59,7 +59,7 @@ class FileInventoryAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.INPUT_FOLDER,
                 self.tr("Input folder"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
         self.addParameter(
@@ -132,7 +132,7 @@ class FileInventoryAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             sinkFields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             QgsCoordinateReferenceSystem.fromEpsgId(4326),
         )
 
@@ -145,7 +145,7 @@ class FileInventoryAlgorithm(QgsProcessingAlgorithm):
             destination_folder=copyFolder,
         )
 
-        output_sink.addFeatures(featList, QgsFeatureSink.FastInsert)
+        output_sink.addFeatures(featList, QgsFeatureSink.Flag.FastInsert)
 
         return {"OUTPUT": self.output_dest_id}
 
@@ -156,7 +156,7 @@ class FileInventoryAlgorithm(QgsProcessingAlgorithm):
         actions = processed_layer.actions()
         field = '[% "fileName" %]'
         action = QgsAction(
-            QgsAction.GenericPython,
+            QgsAction.ActionType.GenericPython,
             "Load Layer",
             f"from pathlib import Path\np=Path(r'{field}')\nlyr = QgsVectorLayer(str(p), p.stem, 'ogr')\nif lyr.isValid(): qgis.utils.iface.addVectorLayer(str(p), p.stem, 'ogr')\nelse: qgis.utils.iface.addRasterLayer(str(p), p.stem)",
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/filterLayerListByGeographicBoundary.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/filterLayerListByGeographicBoundary.py
@@ -59,14 +59,14 @@ class FilterLayerListByGeographicBoundary(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -181,7 +181,7 @@ class FilterLayerListByGeographicBoundary(QgsProcessingAlgorithm):
             list(
                 map(
                     lambda x: self.flagSinkDict[geomType].addFeature(
-                        x, QgsFeatureSink.FastInsert
+                        x, QgsFeatureSink.Flag.FastInsert
                     ),
                     merged.getFeatures(),
                 )
@@ -205,7 +205,7 @@ class FilterLayerListByGeographicBoundary(QgsProcessingAlgorithm):
             self.POINT_OUTPUT,
             context,
             self.fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             outputCrs,
         )
         self.line_flag_sink, self.line_flag_id = self.parameterAsSink(
@@ -213,7 +213,7 @@ class FilterLayerListByGeographicBoundary(QgsProcessingAlgorithm):
             self.LINE_OUTPUT,
             context,
             self.fields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             outputCrs,
         )
         self.poly_flag_sink, self.poly_flag_id = self.parameterAsSink(
@@ -221,7 +221,7 @@ class FilterLayerListByGeographicBoundary(QgsProcessingAlgorithm):
             self.POLYGON_OUTPUT,
             context,
             self.fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             outputCrs,
         )
         self.flagSinkDict = {

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/filterLayerListByGeometryType.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/filterLayerListByGeometryType.py
@@ -47,7 +47,7 @@ class FilterLayerListByGeometryType(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addOutput(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/loadTrackerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/loadTrackerAlgorithm.py
@@ -66,7 +66,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Track Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -80,7 +80,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.ELEVATION_FIELD,
                 self.tr("Elevation field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="ele",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -91,7 +91,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.CREATION_FIELD,
                 self.tr("Date and time field"),
-                type=QgsProcessingParameterField.DateTime,
+                type=QgsProcessingParameterField.DataType.DateTime,
                 defaultValue="time",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -102,7 +102,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKID_FIELD,
                 self.tr("Track id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_fid",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -113,7 +113,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKSEGID_FIELD,
                 self.tr("Track seg id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_seg_id",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -124,7 +124,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKSEGPOINTID_FIELD,
                 self.tr("Point seg id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_seg_point_id",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -148,7 +148,7 @@ class LoadTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.OUTPUT_DB,
                 self.tr("Output database Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
                 defaultValue="aux_track_p",
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/multipleOutputUnitTestAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/multipleOutputUnitTestAlgorithm.py
@@ -133,7 +133,7 @@ class MultipleOutputUnitTestAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             self.getFields(),
-            QgsWkbTypes.NoGeometry,
+            QgsWkbTypes.Type.NoGeometry,
             QgsCoordinateReferenceSystem("EPSG:4326"),
         )
         tester = Tester()
@@ -175,7 +175,7 @@ class MultipleOutputUnitTestAlgorithm(QgsProcessingAlgorithm):
                 )
             )
             feedback.setProgress(currentStep * totalProgress)
-        algsOutput.addFeatures(feats, QgsFeatureSink.FastInsert)
+        algsOutput.addFeatures(feats, QgsFeatureSink.Flag.FastInsert)
         if failCount:
             feedback.reportError(
                 self.tr("{0} algorithms failed their unit tests.").format(failCount)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/raiseFlagsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/raiseFlagsAlgorithm.py
@@ -55,7 +55,9 @@ class RaiseFlagsAlgorithm(QgsProcessingAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input"), [QgsProcessing.TypeVectorAnyGeometry]
+                self.INPUT,
+                self.tr("Input"),
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/ruleStatisticsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/ruleStatisticsAlgorithm.py
@@ -111,14 +111,14 @@ class RuleStatisticsAlgorithm(QgsProcessingAlgorithm):
             self.FLAGS,
             context,
             fields,
-            geometryType=QgsWkbTypes.NoGeometry,
+            geometryType=QgsWkbTypes.Type.NoGeometry,
         )
         (unusualSink, unusual_output_id) = self.parameterAsSink(
             parameters,
             self.UNUSUAL_ATTRIBUTES,
             context,
             fields,
-            geometryType=QgsWkbTypes.NoGeometry,
+            geometryType=QgsWkbTypes.Type.NoGeometry,
         )
         flagOutputDict = {
             "Atributo incomum": unusualSink,

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/selectFeaturesOnCurrentCanvas.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/selectFeaturesOnCurrentCanvas.py
@@ -45,7 +45,7 @@ class SelectFeaturesOnCurrentCanvas(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addOutput(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/singleOutputUnitTestAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/singleOutputUnitTestAlgorithm.py
@@ -162,7 +162,7 @@ class SingleOutputUnitTestAlgorithm(QgsProcessingAlgorithm):
             self.OUTPUT,
             context,
             self.getFields(),
-            QgsWkbTypes.NoGeometry,
+            QgsWkbTypes.Type.NoGeometry,
             QgsCoordinateReferenceSystem("EPSG:4326"),
         )
         tester = Tester()
@@ -200,7 +200,7 @@ class SingleOutputUnitTestAlgorithm(QgsProcessingAlgorithm):
                 )
             )
             feedback.setProgress(currentStep * totalProgress)
-        algsOutput.addFeatures(feats, QgsFeatureSink.FastInsert)
+        algsOutput.addFeatures(feats, QgsFeatureSink.Flag.FastInsert)
         if failCount:
             feedback.reportError(
                 self.tr("{0} algorithms failed their unit tests.").format(failCount)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/updateRunwayAltitudeAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/updateRunwayAltitudeAlgorithm.py
@@ -29,7 +29,7 @@ class UpdateRunwayAltitudeAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input Layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 
@@ -44,7 +44,7 @@ class UpdateRunwayAltitudeAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.DECIMALS,
                 self.tr("Round to how many decimal places (-1 to not round)"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=-1,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/validateTrackerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/OtherAlgs/validateTrackerAlgorithm.py
@@ -52,7 +52,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Track Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -61,7 +61,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
                 self.TOLERANCE,
                 self.tr("Max difference between today and tracker (days)"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
             )
         )
@@ -70,7 +70,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.ELEVATION_FIELD,
                 self.tr("Elevation field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="ele",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -81,7 +81,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.CREATION_FIELD,
                 self.tr("Date and time field"),
-                type=QgsProcessingParameterField.DateTime,
+                type=QgsProcessingParameterField.DataType.DateTime,
                 defaultValue="time",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -92,7 +92,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKID_FIELD,
                 self.tr("Track id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_fid",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -103,7 +103,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKSEGID_FIELD,
                 self.tr("Track seg id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_seg_id",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,
@@ -114,7 +114,7 @@ class ValidateTrackerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.TRACKSEGPOINTID_FIELD,
                 self.tr("Point seg id field"),
-                type=QgsProcessingParameterField.Numeric,
+                type=QgsProcessingParameterField.DataType.Numeric,
                 defaultValue="track_seg_point_id",
                 parentLayerParameterName=self.INPUT,
                 allowMultiple=False,

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/batchRasterPackagingForBDGEx.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/batchRasterPackagingForBDGEx.py
@@ -67,14 +67,14 @@ class BatchRasterPackagingForBDGEx(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.INPUT_FOLDER,
                 self.tr("Folder with tif files"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
         self.addParameter(
             QgsProcessingParameterFile(
                 self.XML_TEMPLATE_FILE,
                 self.tr("XML template"),
-                behavior=QgsProcessingParameterFile.File,
+                behavior=QgsProcessingParameterFile.Behavior.File,
                 fileFilter="XML (*.xml)",
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/medianFilterNoDataAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/medianFilterNoDataAlgorithm.py
@@ -409,7 +409,7 @@ class MedianFilterNoDataAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.WINDOW_SIZE,
                 self.tr("Window size"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=3,
                 minValue=3,
                 maxValue=21,
@@ -421,7 +421,7 @@ class MedianFilterNoDataAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MIN_VALID_PIXELS,
                 self.tr("Minimum valid pixels required"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
                 minValue=1,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/prepareFilesForRasterPackagingForBDGEx.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/prepareFilesForRasterPackagingForBDGEx.py
@@ -54,7 +54,7 @@ class PrepareRasterFilesForPackagingForBDGEx(QgsProcessingAlgorithm):
             QgsProcessingParameterFile(
                 self.INPUT_FOLDER,
                 self.tr("Folder with zip files"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
         self.addParameter(
@@ -243,7 +243,7 @@ class PrepareRasterFilesForPackagingForBDGEx(QgsProcessingAlgorithm):
                         "ESRI Shapefile",
                     )
 
-                    if writer.hasError() != QgsVectorFileWriter.NoError:
+                    if writer.hasError() != QgsVectorFileWriter.WriterError.NoError:
                         raise QgsProcessingException(
                             self.tr("Error creating writer for {}").format(output_file)
                         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/rasterRemapAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/rasterRemapAlgorithm.py
@@ -106,7 +106,9 @@ class RasterRemapAlgorithm(QgsProcessingAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(
             QgsProcessingParameterRasterLayer(
-                self.INPUT_RASTER, self.tr("Input Raster"), [QgsProcessing.TypeRaster]
+                self.INPUT_RASTER,
+                self.tr("Input Raster"),
+                [QgsProcessing.SourceType.TypeRaster],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/rasterizePolygonsWithBuffer.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/rasterizePolygonsWithBuffer.py
@@ -102,7 +102,7 @@ class RasterizePolygonsWithBufferAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=False,
             )
         )
@@ -119,7 +119,7 @@ class RasterizePolygonsWithBufferAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SEARCH_RADIUS,
                 self.tr("Search Radius (Buffer)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=-1e-4,
                 optional=False,
             )
@@ -130,7 +130,7 @@ class RasterizePolygonsWithBufferAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.NODATA_VALUE,
                 self.tr("NoData Value"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=-9999,
                 optional=False,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/trataRasterAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/RasterAlgs/trataRasterAlgorithm.py
@@ -160,7 +160,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.AREA_EDIFICADA,
                 self.tr("Built-up Area (Polygons)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
             )
         )
@@ -169,7 +169,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.MASSA_DAGUA,
                 self.tr("Water Body (Polygons)"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
             )
         )
@@ -178,7 +178,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.AREA_EDIFICADA_VALUE,
                 self.tr("DN Value for Built-up Area Class"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=2,
             )
         )
@@ -187,7 +187,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.MASSA_DAGUA_VALUE,
                 self.tr("DN Value for Water Body Class"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=1,
             )
         )
@@ -196,7 +196,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.NODATA_VALUE,
                 self.tr("NoData Value"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=-9999,
             )
         )
@@ -205,7 +205,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.BUFFER_DISTANCE,
                 self.tr("Negative Buffer Distance (raster CRS units)"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=-5,
             )
         )
@@ -214,7 +214,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SIEVE_THRESHOLD,
                 self.tr("Sieve Threshold (pixels)"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=50,
             )
         )
@@ -223,7 +223,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.FIRST_PASS_MIN_AREA,
                 self.tr("Minimum Area - Pass 1 (m2)"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=15625,
             )
         )
@@ -232,7 +232,7 @@ class TrataRasterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterNumber(
                 self.SECOND_PASS_MIN_AREA,
                 self.tr("Minimum Area - Pass 2 (m2)"),
-                type=QgsProcessingParameterNumber.Integer,
+                type=QgsProcessingParameterNumber.Type.Integer,
                 defaultValue=62500,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/addUnsharedVertexOnIntersectionsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/addUnsharedVertexOnIntersectionsAlgorithm.py
@@ -54,7 +54,7 @@ class AddUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POINTS,
                 self.tr("Point Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -62,7 +62,7 @@ class AddUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LINES,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -70,7 +70,7 @@ class AddUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -91,7 +91,7 @@ class AddUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/addUnsharedVertexOnSharedEdgesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/addUnsharedVertexOnSharedEdgesAlgorithm.py
@@ -52,7 +52,7 @@ class AddUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LINES,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -60,7 +60,7 @@ class AddUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -80,7 +80,7 @@ class AddUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/adjustNetworkConnectivityAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/adjustNetworkConnectivityAlgorithm.py
@@ -47,7 +47,9 @@ class AdjustNetworkConnectivityAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/anchoredSnapperAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/anchoredSnapperAlgorithm.py
@@ -59,7 +59,7 @@ class AnchoredSnapperAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT,
                 self.tr("Input layers to be snapped"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addParameter(
@@ -73,7 +73,7 @@ class AnchoredSnapperAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_ANCHOR_LAYERS,
                 self.tr("Point anchor layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -82,7 +82,7 @@ class AnchoredSnapperAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_ANCHOR_LAYERS,
                 self.tr("Line anchor layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -91,7 +91,7 @@ class AnchoredSnapperAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGON_ANCHOR_LAYERS,
                 self.tr("Polygon anchor layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -133,7 +133,7 @@ class AnchoredSnapperAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/buildPolygonsFromCenterPointsAndBoundariesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/buildPolygonsFromCenterPointsAndBoundariesAlgorithm.py
@@ -74,7 +74,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_CENTER_POINTS,
                 self.tr("Center Point Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
         self.addParameter(
@@ -83,7 +83,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT_CENTER_POINTS",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -92,7 +92,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.BOUNDARY_LINE_LAYER,
                 self.tr("Line Boundary"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=True,
             )
         )
@@ -100,7 +100,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.CONSTRAINT_LINE_LAYERS,
                 self.tr("Line Constraint Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -108,7 +108,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.CONSTRAINT_POLYGON_LAYERS,
                 self.tr("Polygon Constraint Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -116,7 +116,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -225,7 +225,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             self.OUTPUT_POLYGONS,
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             inputCenterPointLyr.sourceCrs(),
         )
         suppressPolygonWithoutCenterPointFlag = self.parameterAsBool(
@@ -242,7 +242,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
         )
 
         self.prepareFlagSink(
-            parameters, inputCenterPointLyr, QgsWkbTypes.Polygon, context
+            parameters, inputCenterPointLyr, QgsWkbTypes.Type.Polygon, context
         )
         (
             unused_boundary_flag_sink,
@@ -252,7 +252,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             self.UNUSED_BOUNDARY_LINES,
             context,
             boundaryLineLyr.fields() if boundaryLineLyr is not None else QgsFields(),
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             boundaryLineLyr.sourceCrs()
             if boundaryLineLyr is not None
             else inputCenterPointLyr.sourceCrs(),
@@ -300,10 +300,10 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             "memory:",
             context,
             fields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             inputCenterPointLyr.sourceCrs(),
         )
-        sink.addFeatures(polygonFeatList, QgsFeatureSink.FastInsert)
+        sink.addFeatures(polygonFeatList, QgsFeatureSink.Flag.FastInsert)
 
         if mergeOutput:
             multiStepFeedback.setCurrentStep(currentStep)
@@ -508,7 +508,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             mergedSegments, context, feedback=multiStepFeedback
         )
         unused_boundary_flag_sink.addFeatures(
-            flagLyr.getFeatures(), QgsFeatureSink.FastInsert
+            flagLyr.getFeatures(), QgsFeatureSink.Flag.FastInsert
         )
 
     def checkInvalidOnOutput(
@@ -565,7 +565,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             self.INVALID_POLYGON_LOCATION,
             context,
             self.getFlagFields(),
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             inputCenterPointLyr.sourceCrs(),
         )
 
@@ -575,7 +575,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
         self, output_polygon_sink, multiStepFeedback, polygonFeatList, flagDict
     ):
         multiStepFeedback.setProgressText(self.tr("Writing output..."))
-        output_polygon_sink.addFeatures(polygonFeatList, QgsFeatureSink.FastInsert)
+        output_polygon_sink.addFeatures(polygonFeatList, QgsFeatureSink.Flag.FastInsert)
         nItems = len(flagDict)
         for current, (flagGeom, flagText) in enumerate(flagDict.items()):
             if multiStepFeedback.isCanceled():
@@ -974,7 +974,7 @@ class BuildPolygonsFromCenterPointsAndBoundariesAlgorithm(ValidationAlgorithm):
             if localFlagLyr is None or localFlagLyr.featureCount() == 0:
                 continue
             unused_boundary_flag_sink.addFeatures(
-                localFlagLyr.getFeatures(), QgsFeatureSink.FastInsert
+                localFlagLyr.getFeatures(), QgsFeatureSink.Flag.FastInsert
             )
 
     @staticmethod

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/cleanGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/cleanGeometriesAlgorithm.py
@@ -57,7 +57,7 @@ class CleanGeometriesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -79,7 +79,7 @@ class CleanGeometriesAlgorithm(ValidationAlgorithm):
             self.tr("Minimum area"),
             minValue=0,
             defaultValue=1e-8,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         areaParam.setMetadata({"widget_wrapper": {"decimals": 16}})
         self.addParameter(areaParam)
@@ -88,7 +88,7 @@ class CleanGeometriesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Bounds Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/deaggregateGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/deaggregateGeometriesAlgorithm.py
@@ -50,7 +50,7 @@ class DeaggregatorAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -130,7 +130,7 @@ class DeaggregatorAlgorithm(QgsProcessingAlgorithm):
                 featuresToAdd += newFeatList
             feedback.setProgress(int(current * stepSize))
         if featuresToAdd:
-            inputLyr.addFeatures(featuresToAdd, QgsFeatureSink.FastInsert)
+            inputLyr.addFeatures(featuresToAdd, QgsFeatureSink.Flag.FastInsert)
         inputLyr.endEditCommand()
         return {}
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/detectChangesGroupAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/detectChangesGroupAlgorithm.py
@@ -140,13 +140,23 @@ class DetectChangesBetweenGroups(ValidationAlgorithm):
         dictLyrsReviewed, crs = self.dictNameLyrCrs(groupR)
 
         point_flag_sink, point_flag_id = self.sinkLyr(
-            parameters, self.POINT_FLAG, context, fields, QgsWkbTypes.Point, crs
+            parameters, self.POINT_FLAG, context, fields, QgsWkbTypes.Type.Point, crs
         )
         line_flag_sink, line_flag_id = self.sinkLyr(
-            parameters, self.LINE_FLAG, context, fields, QgsWkbTypes.LineString, crs
+            parameters,
+            self.LINE_FLAG,
+            context,
+            fields,
+            QgsWkbTypes.Type.LineString,
+            crs,
         )
         poly_flag_sink, poly_flag_id = self.sinkLyr(
-            parameters, self.POLYGON_FLAG, context, fields, QgsWkbTypes.Polygon, crs
+            parameters,
+            self.POLYGON_FLAG,
+            context,
+            fields,
+            QgsWkbTypes.Type.Polygon,
+            crs,
         )
 
         multiStepFeedback = QgsProcessingMultiStepFeedback(
@@ -325,11 +335,11 @@ class DetectChangesBetweenGroups(ValidationAlgorithm):
         newFeat["type_change"] = type_change
         newFeat["update"] = flagMsg
         if lyrPoint:
-            point_flag_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            point_flag_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
         elif lyrLine:
-            line_flag_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            line_flag_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
         elif lyrPolygon:
-            poly_flag_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            poly_flag_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def fieldsFlag(self, attributeGroup):
         fields = QgsFields()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/dissolvePolygonsWithSameAttributesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/dissolvePolygonsWithSameAttributesAlgorithm.py
@@ -51,7 +51,9 @@ class DissolvePolygonsWithSameAttributesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorPolygon]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
@@ -74,7 +76,7 @@ class DissolvePolygonsWithSameAttributesAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -119,7 +121,7 @@ class DissolvePolygonsWithSameAttributesAlgorithm(ValidationAlgorithm):
         multiStepFeedback.pushInfo(self.tr("Populating temp layer...\n"))
         unifiedLyr = layerHandler.createAndPopulateUnifiedVectorLayer(
             [inputLyr],
-            geomType=QgsWkbTypes.MultiPolygon,
+            geomType=QgsWkbTypes.Type.MultiPolygon,
             attributeBlackList=attributeBlackList,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/enforceAttributeRulesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/enforceAttributeRulesAlgorithm.py
@@ -138,7 +138,7 @@ class EnforceAttributeRulesAlgorithm(QgsProcessingAlgorithm):
             self.POINT_FLAGS,
             context,
             self.flagFields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             crs,
         )
 
@@ -152,7 +152,7 @@ class EnforceAttributeRulesAlgorithm(QgsProcessingAlgorithm):
             self.LINE_FLAGS,
             context,
             self.flagFields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             crs,
         )
 
@@ -166,7 +166,7 @@ class EnforceAttributeRulesAlgorithm(QgsProcessingAlgorithm):
             self.POLYGON_FLAGS,
             context,
             self.flagFields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             crs,
         )
 
@@ -236,7 +236,9 @@ class EnforceAttributeRulesAlgorithm(QgsProcessingAlgorithm):
                 newFeature = QgsFeature(self.flagFields)
                 newFeature["reason"] = flagText
                 newFeature.setGeometry(geom)
-                layerMap[geom.type()].addFeature(newFeature, QgsFeatureSink.FastInsert)
+                layerMap[geom.type()].addFeature(
+                    newFeature, QgsFeatureSink.Flag.FastInsert
+                )
         self.logResult(attrRulesMap, feedback)
         return (ptLayer, lLayer, polLayer)
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/enforceSpatialRulesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/enforceSpatialRulesAlgorithm.py
@@ -156,7 +156,7 @@ class EnforceSpatialRulesAlgorithm(ValidationAlgorithm):
                         newFeature["reason"] = flagText.format(text=flag["text"])
                         newFeature.setGeometry(g)
                         layerMap[g.type()].addFeature(
-                            newFeature, QgsFeatureSink.FastInsert
+                            newFeature, QgsFeatureSink.Flag.FastInsert
                         )
         return (ptLayer, lLayer, polLayer)
 
@@ -184,7 +184,12 @@ class EnforceSpatialRulesAlgorithm(ValidationAlgorithm):
         flagFields = self.getFlagFields()
         crs = QgsProject.instance().crs()
         pointFlags, ptId = self.parameterAsSink(
-            parameters, self.POINT_FLAGS, context, flagFields, QgsWkbTypes.Point, crs
+            parameters,
+            self.POINT_FLAGS,
+            context,
+            flagFields,
+            QgsWkbTypes.Type.Point,
+            crs,
         )
         if not pointFlags:
             raise QgsProcessingException(
@@ -195,7 +200,7 @@ class EnforceSpatialRulesAlgorithm(ValidationAlgorithm):
             self.LINE_FLAGS,
             context,
             flagFields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             crs,
         )
         if not lineFlags:
@@ -207,7 +212,7 @@ class EnforceSpatialRulesAlgorithm(ValidationAlgorithm):
             self.POLYGON_FLAGS,
             context,
             flagFields,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             crs,
         )
         if not polygonFlags:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/extendLinesToGeographicBoundsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/extendLinesToGeographicBoundsAlgorithm.py
@@ -52,7 +52,7 @@ class ExtendLinesToGeographicBoundsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -65,7 +65,7 @@ class ExtendLinesToGeographicBoundsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.GEOGRAPHIC_BOUNDS_LAYER,
                 self.tr("Geographic bounds"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixDrainageFlowAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixDrainageFlowAlgorithm.py
@@ -73,7 +73,7 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.NETWORK_LAYER,
                 self.tr("Network layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -89,14 +89,14 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDS_LAYER,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODY_LAYER,
                 self.tr("Water body layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -132,7 +132,7 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.SINK_AND_SPILLWAY_LAYER,
                 self.tr("Water sink and spillway layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
                 optional=True,
             )
         )
@@ -270,7 +270,7 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             self.POINT_FLAGS,
             context,
             self.getFlagFields(),
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             networkLayer.sourceCrs(),
         )
         (self.line_flags_sink, self.line_flags_sink_id) = self.parameterAsSink(
@@ -278,7 +278,7 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             self.LINE_FLAGS,
             context,
             self.getFlagFields(),
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             networkLayer.sourceCrs(),
         )
         (self.polygon_flags_sink, self.polygon_flags_sink_id) = self.parameterAsSink(
@@ -286,7 +286,7 @@ class FixDrainageFlowAlgorithm(ValidationAlgorithm):
             self.POLYGON_FLAGS,
             context,
             self.getFlagFields(),
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             networkLayer.sourceCrs(),
         )
         nSteps = (

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixDrainageVersusWaterBodyAttributeAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixDrainageVersusWaterBodyAttributeAlgorithm.py
@@ -58,7 +58,7 @@ class FixDrainageVersusWaterBodyAttributeAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_DRAINAGES,
                 self.tr("Input Drainages layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_trecho_drenagem_l",
             )
         )
@@ -68,7 +68,7 @@ class FixDrainageVersusWaterBodyAttributeAlgorithm(ValidationAlgorithm):
                 self.tr("Attribute that indicates the relationship with polygon"),
                 "situacao_em_poligono",
                 parentLayerParameterName=self.INPUT_DRAINAGES,
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
                 allowMultiple=False,
             )
         )
@@ -86,7 +86,7 @@ class FixDrainageVersusWaterBodyAttributeAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODY,
                 self.tr("Water body"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_massa_dagua_a",
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixNetworkAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixNetworkAlgorithm.py
@@ -53,7 +53,9 @@ class FixNetworkAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -76,7 +78,7 @@ class FixNetworkAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -135,7 +137,7 @@ class FixNetworkAlgorithm(ValidationAlgorithm):
             multiStepFeedback.pushInfo(self.tr("Building auxiliar layer..."))
             coverage = layerHandler.createAndPopulateUnifiedVectorLayer(
                 [inputLyr],
-                geomType=QgsWkbTypes.MultiPolygon,
+                geomType=QgsWkbTypes.Type.MultiPolygon,
                 onlySelected=onlySelected,
                 feedback=multiStepFeedback,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixSegmentErrorsBetweenLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/fixSegmentErrorsBetweenLinesAlgorithm.py
@@ -45,21 +45,23 @@ class FixSegmentErrorsBetweenLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterFeatureSource(
-                self.INPUT, self.tr("Input lines"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input lines"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterFeatureSource(
                 self.REFERENCE_LINE,
                 self.tr("Reference lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.SEARCH_RADIUS,
                 self.tr("Search Radius"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/hierarchicalSnapLayerOnLayerAndUpdateAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/hierarchicalSnapLayerOnLayerAndUpdateAlgorithm.py
@@ -76,7 +76,7 @@ class HierarchicalSnapLayerOnLayerAndUpdateAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAndFixInvalidGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAndFixInvalidGeometriesAlgorithm.py
@@ -49,7 +49,7 @@ class IdentifyAndFixInvalidGeometriesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -87,7 +87,7 @@ class IdentifyAndFixInvalidGeometriesAlgorithm(ValidationAlgorithm):
         ignoreClosed = self.parameterAsBool(parameters, self.IGNORE_CLOSED, context)
         fixInput = self.parameterAsBool(parameters, self.TYPE, context)
         self.prepareFlagSink(
-            parameters, inputLyr, QgsWkbTypes.Point, context, addFeatId=True
+            parameters, inputLyr, QgsWkbTypes.Type.Point, context, addFeatId=True
         )
 
         multiStepFeedback = QgsProcessingMultiStepFeedback(2, feedback)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAnglesInInvalidRangeAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAnglesInInvalidRangeAlgorithm.py
@@ -52,7 +52,10 @@ class IdentifyAnglesInInvalidRangeAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 
@@ -95,7 +98,7 @@ class IdentifyAnglesInInvalidRangeAlgorithm(ValidationAlgorithm):
         maxAngle = self.parameterAsDouble(parameters, self.MAX_ANGLE, context)
         if maxAngle <= minAngle:
             raise QgsProcessingException(self.tr("Invalid Range"))
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         featureList, total = self.getIteratorAndFeatureCount(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAttributeChangesInLines.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyAttributeChangesInLines.py
@@ -59,14 +59,14 @@ class IdentifyAttributeChangesInLines(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LAYER,
                 self.tr("Input Layer"),
-                types=[QgsProcessing.TypeVectorLine],
+                types=[QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterField(
                 self.INPUT_FIELDS,
                 self.tr("Fields to consider"),
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
                 parentLayerParameterName="INPUT_LAYER",
                 allowMultiple=True,
             )
@@ -76,7 +76,7 @@ class IdentifyAttributeChangesInLines(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.INPUT_ANGLE,
                 self.tr("Maximum angle between lines"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
             )
         )
@@ -85,7 +85,7 @@ class IdentifyAttributeChangesInLines(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.INPUT_MAX_SIZE,
                 self.tr("Maximum size"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 optional=True,
                 minValue=0,
             )
@@ -103,7 +103,7 @@ class IdentifyAttributeChangesInLines(ValidationAlgorithm):
         angle = self.parameterAsDouble(parameters, self.INPUT_ANGLE, context)
         maxLength = self.parameterAsDouble(parameters, self.INPUT_MAX_SIZE, context)
         algRunner = AlgRunner()
-        self.prepareFlagSink(parameters, layer, QgsWkbTypes.MultiPoint, context)
+        self.prepareFlagSink(parameters, layer, QgsWkbTypes.Type.MultiPoint, context)
         multiStepFeedback = QgsProcessingMultiStepFeedback(4, feedback)
         currentStep = 0
         multiStepFeedback.setCurrentStep(currentStep)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCloseFeaturesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCloseFeaturesAlgorithm.py
@@ -91,7 +91,9 @@ class IdentifyCloseFeaturesAlgorithm(ValidationAlgorithm):
         minimumDistances = self.parameterAsMinimumDistanceBetweenLayers(
             parameters, self.DISTANCE_BETWEEN_LAYERS, context
         )
-        self.prepareFlagSink(parameters, None, QgsWkbTypes.MultiLineString, context)
+        self.prepareFlagSink(
+            parameters, None, QgsWkbTypes.Type.MultiLineString, context
+        )
         if not minimumDistances:
             raise QgsProcessingException(
                 self.invalidSourceError(parameters, self.DISTANCE_BETWEEN_LAYERS)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCountourStreamIntersectionAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCountourStreamIntersectionAlgorithm.py
@@ -52,14 +52,14 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 "INPUT_STREAM",
                 self.tr("Drainage layer"),
-                types=[QgsProcessing.TypeVectorLine],
+                types=[QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 "INPUT_COUNTOUR_LINES",
                 self.tr("Contour levels layer"),
-                types=[QgsProcessing.TypeVectorLine],
+                types=[QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -87,7 +87,7 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
             self.POINT_FLAGS,
             context,
             streamLayerInput.fields(),
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             streamLayerInput.sourceCrs(),
         )
 
@@ -96,7 +96,7 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
             self.LINE_FLAGS,
             context,
             streamLayerInput.fields(),
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             streamLayerInput.sourceCrs(),
         )
 
@@ -151,7 +151,7 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
                 context,
                 outputPointsSet,
                 streamLayerInput,
-                QgsWkbTypes.Point,
+                QgsWkbTypes.Type.Point,
                 point_flag_sink,
             )
         if outputLinesSet != set():
@@ -160,7 +160,7 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
                 context,
                 outputLinesSet,
                 streamLayerInput,
-                QgsWkbTypes.LineString,
+                QgsWkbTypes.Type.LineString,
                 line_flag_sink,
             )
         return {
@@ -224,13 +224,16 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
                 return
             countourGeom = idDict[riverFeat["AUTO_2"]].geometry()
             intersection = countourGeom.intersection(riverGeom)
-            if intersection.isEmpty() or intersection.wkbType() == QgsWkbTypes.Point:
+            if (
+                intersection.isEmpty()
+                or intersection.wkbType() == QgsWkbTypes.Type.Point
+            ):
                 return
-            if intersection.wkbType() == QgsWkbTypes.MultiPoint:
+            if intersection.wkbType() == QgsWkbTypes.Type.MultiPoint:
                 outputPointsSet.add(intersection)
             if intersection.wkbType() in [
-                QgsWkbTypes.LineString,
-                QgsWkbTypes.MultiLineString,
+                QgsWkbTypes.Type.LineString,
+                QgsWkbTypes.Type.MultiLineString,
             ]:
                 outputLinesSet.add(intersection)
 
@@ -260,7 +263,7 @@ class IdentifyCountourStreamIntersectionAlgorithm(ValidationAlgorithm):
             newFeat.setGeometry(geom)
             newFeat.setFields(newFields)
             newFeat["id"] = idcounter
-            sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def name(self):
         """

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCrossingLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyCrossingLinesAlgorithm.py
@@ -52,14 +52,16 @@ class IdentifyCrossingLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input lines"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input lines"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
                 self.COMPARE_INPUT,
                 self.tr("Compare lines"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addParameter(
@@ -75,7 +77,7 @@ class IdentifyCrossingLinesAlgorithm(ValidationAlgorithm):
         self.algRunner = AlgRunner()
         input = self.parameterAsVectorLayer(parameters, self.INPUT, context)
         compareList = self.parameterAsLayerList(parameters, self.COMPARE_INPUT, context)
-        self.prepareFlagSink(parameters, input, QgsWkbTypes.MultiPoint, context)
+        self.prepareFlagSink(parameters, input, QgsWkbTypes.Type.MultiPoint, context)
         nFeats = input.featureCount()
         if input is None or nFeats == 0 or compareList == 0:
             return {self.FLAGS: self.flag_id}
@@ -96,7 +98,7 @@ class IdentifyCrossingLinesAlgorithm(ValidationAlgorithm):
         for current, feat in enumerate(pointLyr.getFeatures()):
             if feedback is not None and feedback.isCanceled():
                 return {self.FLAGS: self.flag_id}
-            self.flagSink.addFeature(feat, QgsFeatureSink.FastInsert)
+            self.flagSink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
             multiStepFeedback.setProgress(current * stepSize)
         return {self.FLAGS: self.flag_id}
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDanglesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDanglesAlgorithm.py
@@ -67,7 +67,9 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -89,7 +91,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
                 self.TOLERANCE,
                 self.tr("Search radius"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.0001,
             )
         )
@@ -97,7 +99,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINEFILTERLAYERS,
                 self.tr("Linestring Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -105,7 +107,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGONFILTERLAYERS,
                 self.tr("Polygon Filter Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -121,7 +123,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
                 self.tr(
                     "Geographic Boundary (this layer only filters the output dangles)"
                 ),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -138,7 +140,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
         self.layerHandler = LayerHandler()
         algRunner = AlgRunner()
         inputLyr = self.parameterAsVectorLayer(parameters, self.INPUT, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         if inputLyr is None:
             return {self.FLAGS: self.flag_id}
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
@@ -360,7 +362,7 @@ class IdentifyDanglesAlgorithm(ValidationAlgorithm):
         if not lineLyrs:
             return None
         return self.layerHandler.createAndPopulateUnifiedVectorLayer(
-            lineLyrs, QgsWkbTypes.MultiLineString, onlySelected=onlySelected
+            lineLyrs, QgsWkbTypes.Type.MultiLineString, onlySelected=onlySelected
         )
 
     def makeBoundaries(self, lyr, context, feedback):

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageAndContourInconsistencies.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageAndContourInconsistencies.py
@@ -56,7 +56,7 @@ class IdentifyDrainageAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_DRAINAGES,
                 self.tr("Input drainages"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=False,
             )
         )
@@ -65,7 +65,7 @@ class IdentifyDrainageAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_CONTOURS,
                 self.tr("Input contours"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=False,
             )
         )
@@ -76,7 +76,7 @@ class IdentifyDrainageAndContourInconsistencies(ValidationAlgorithm):
                 self.tr("Contour value field"),
                 None,
                 self.INPUT_CONTOURS,
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
 
@@ -84,7 +84,7 @@ class IdentifyDrainageAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.CONTOUR_INTERVAL,
                 self.tr("Contour interval"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=10,
             )
@@ -129,7 +129,7 @@ class IdentifyDrainageAndContourInconsistencies(ValidationAlgorithm):
             feat["d_featid"]: feat for feat in inputDrainagesLyr.getFeatures()
         }
         self.prepareFlagSink(
-            parameters, inputDrainagesLyr, QgsWkbTypes.MultiPoint, context
+            parameters, inputDrainagesLyr, QgsWkbTypes.Type.MultiPoint, context
         )
         if len(drainageDict) == 0:
             return {self.FLAGS: self.flag_id}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageAngleIssues.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageAngleIssues.py
@@ -46,7 +46,7 @@ class IdentifyDrainageAngleIssues(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input"),
                 [
-                    QgsProcessing.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorLine,
                 ],
             )
         )
@@ -58,7 +58,7 @@ class IdentifyDrainageAngleIssues(ValidationAlgorithm):
 
     def processAlgorithm(self, parameters, context, feedback):
         lines = self.parameterAsVectorLayer(parameters, "INPUT", context)
-        self.prepareFlagSink(parameters, lines, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, lines, QgsWkbTypes.Type.Point, context)
 
         # Dictionary that stores azimuths entering and exiting the point
         pointInAndOutDictionary = {}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageFlowIssues.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageFlowIssues.py
@@ -45,7 +45,7 @@ class IdentifyDrainageFlowIssues(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input"),
                 [
-                    QgsProcessing.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorLine,
                 ],
             )
         )
@@ -57,7 +57,7 @@ class IdentifyDrainageFlowIssues(ValidationAlgorithm):
 
     def processAlgorithm(self, parameters, context, feedback):
         lines = self.parameterAsVectorLayer(parameters, "INPUT", context)
-        self.prepareFlagSink(parameters, lines, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, lines, QgsWkbTypes.Type.Point, context)
 
         # Dictionary that indicates how many lines enter and how many lines exit a given point:
         pointInAndOutDictionary = {}

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageFlowIssuesWithOtherHydrographicClassesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageFlowIssuesWithOtherHydrographicClassesAlgorithm.py
@@ -68,7 +68,7 @@ class IdentifyDrainageFlowIssuesWithHydrographyElementsAlgorithm(ValidationAlgor
             QgsProcessingParameterVectorLayer(
                 self.INPUT_DRAINAGES,
                 self.tr("Input Drainages layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_trecho_drenagem_l",
             )
         )
@@ -77,7 +77,7 @@ class IdentifyDrainageFlowIssuesWithHydrographyElementsAlgorithm(ValidationAlgor
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODY_LAYER,
                 self.tr("Water body layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
                 defaultValue="cobter_massa_dagua_a",
             )
@@ -113,7 +113,7 @@ class IdentifyDrainageFlowIssuesWithHydrographyElementsAlgorithm(ValidationAlgor
             QgsProcessingParameterVectorLayer(
                 self.SINK_AND_SPILLWAY_LAYER,
                 self.tr("Water sink and spillway layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
                 optional=True,
             )
         )
@@ -141,7 +141,7 @@ class IdentifyDrainageFlowIssuesWithHydrographyElementsAlgorithm(ValidationAlgor
                 self.tr(
                     "Geographic Boundary (this layer only filters the output dangles)"
                 ),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
                 defaultValue="aux_moldura_a",
             )
@@ -233,19 +233,23 @@ class IdentifyDrainageFlowIssuesWithHydrographyElementsAlgorithm(ValidationAlgor
             parameters, self.GEOGRAPHIC_BOUNDARY, context
         )
         (self.pointFlagSink, self.point_flag_id) = self.prepareAndReturnFlagSink(
-            parameters, inputDrainagesLyr, QgsWkbTypes.Point, context, self.POINT_FLAGS
+            parameters,
+            inputDrainagesLyr,
+            QgsWkbTypes.Type.Point,
+            context,
+            self.POINT_FLAGS,
         )
         (self.lineFlagSink, self.line_flag_id) = self.prepareAndReturnFlagSink(
             parameters,
             inputDrainagesLyr,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             context,
             self.LINE_FLAGS,
         )
         (self.polygonFlagSink, self.polygon_flag_id) = self.prepareAndReturnFlagSink(
             parameters,
             inputDrainagesLyr,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             context,
             self.POLYGON_FLAGS,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageLoops.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageLoops.py
@@ -54,7 +54,7 @@ class IdentifyDrainageLoops(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input"),
                 [
-                    QgsProcessing.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorLine,
                 ],
             )
         )
@@ -84,7 +84,7 @@ class IdentifyDrainageLoops(ValidationAlgorithm):
         if inputLyr.featureCount() == 0:
             return {self.FLAGS: self.flag_id}
         buildCache = self.parameterAsBool(parameters, self.BUILD_CACHE, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.LineString, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.LineString, context)
 
         # Iterate over lines setting the dictionary counters:
         nSteps = 6 if buildCache else 4

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageVersusWaterBodyAttributeErrorsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDrainageVersusWaterBodyAttributeErrorsAlgorithm.py
@@ -56,7 +56,7 @@ class IdentifyDrainageVersusWaterBodyAttributeErrorsAlgorithm(ValidationAlgorith
             QgsProcessingParameterVectorLayer(
                 self.INPUT_DRAINAGES,
                 self.tr("Input Drainages layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_trecho_drenagem_l",
             )
         )
@@ -66,7 +66,7 @@ class IdentifyDrainageVersusWaterBodyAttributeErrorsAlgorithm(ValidationAlgorith
                 self.tr("Attribute that indicates the relationship with polygon"),
                 "situacao_em_poligono",
                 parentLayerParameterName=self.INPUT_DRAINAGES,
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
                 allowMultiple=False,
             )
         )
@@ -84,7 +84,7 @@ class IdentifyDrainageVersusWaterBodyAttributeErrorsAlgorithm(ValidationAlgorith
             QgsProcessingParameterVectorLayer(
                 self.WATER_BODY,
                 self.tr("Water body"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 defaultValue="cobter_massa_dagua_a",
             )
         )
@@ -136,7 +136,7 @@ class IdentifyDrainageVersusWaterBodyAttributeErrorsAlgorithm(ValidationAlgorith
         self.prepareFlagSink(
             parameters,
             inputDrainagesLyr,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             context,
             addFeatId=True,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedFeaturesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedFeaturesAlgorithm.py
@@ -53,7 +53,7 @@ class IdentifyDuplicatedFeaturesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -69,7 +69,7 @@ class IdentifyDuplicatedFeaturesAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedGeometriesAlgorithm.py
@@ -47,7 +47,7 @@ class IdentifyDuplicatedGeometriesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedLinesBetweenLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedLinesBetweenLayersAlgorithm.py
@@ -49,7 +49,7 @@ class IdentifyDuplicatedLinesBetweenLayersAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Coverage Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -77,7 +77,7 @@ class IdentifyDuplicatedLinesBetweenLayersAlgorithm(ValidationAlgorithm):
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
         self.prepareFlagSink(
-            parameters, inputLyrList[0], QgsWkbTypes.LineString, context
+            parameters, inputLyrList[0], QgsWkbTypes.Type.LineString, context
         )
         # Compute the number of steps to display within the progress bar and
         # get features from source

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedPointsBetweenLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedPointsBetweenLayersAlgorithm.py
@@ -47,7 +47,9 @@ class IdentifyDuplicatedPointsBetweenLayersAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
-                self.INPUTLAYERS, self.tr("Point Layers"), QgsProcessing.TypeVectorPoint
+                self.INPUTLAYERS,
+                self.tr("Point Layers"),
+                QgsProcessing.SourceType.TypeVectorPoint,
             )
         )
 
@@ -74,7 +76,9 @@ class IdentifyDuplicatedPointsBetweenLayersAlgorithm(ValidationAlgorithm):
                 self.invalidSourceError(parameters, self.INPUTLAYERS)
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
-        self.prepareFlagSink(parameters, inputLyrList[0], QgsWkbTypes.Point, context)
+        self.prepareFlagSink(
+            parameters, inputLyrList[0], QgsWkbTypes.Type.Point, context
+        )
         # Compute the number of steps to display within the progress bar and
         # get features from source
         geomDict = dict()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedPolygonsBetweenLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedPolygonsBetweenLayersAlgorithm.py
@@ -49,7 +49,7 @@ class IdentifyDuplicatedPolygonsBetweenLayersAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Coverage Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
 
@@ -76,7 +76,9 @@ class IdentifyDuplicatedPolygonsBetweenLayersAlgorithm(ValidationAlgorithm):
                 self.invalidSourceError(parameters, self.INPUTLAYERS)
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
-        self.prepareFlagSink(parameters, inputLyrList[0], QgsWkbTypes.Polygon, context)
+        self.prepareFlagSink(
+            parameters, inputLyrList[0], QgsWkbTypes.Type.Polygon, context
+        )
         # Compute the number of steps to display within the progress bar and
         # get features from source
         geomDict = dict()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedVertexesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyDuplicatedVertexesAlgorithm.py
@@ -53,7 +53,10 @@ class IdentifyDuplicatedVertexesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 
@@ -80,7 +83,7 @@ class IdentifyDuplicatedVertexesAlgorithm(ValidationAlgorithm):
                 self.invalidSourceError(parameters, self.INPUT)
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
 
         multiStepFeedback = QgsProcessingMultiStepFeedback(5, feedback)
         multiStepFeedback.setCurrentStep(0)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyErrorsInContourAttributesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyErrorsInContourAttributesAlgorithm.py
@@ -53,7 +53,7 @@ class IdentifyErrorsInContourAttributesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_CONTOURS,
                 self.tr("Input Contours layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_curva_nivel_l",
             )
         )
@@ -63,7 +63,7 @@ class IdentifyErrorsInContourAttributesAlgorithm(ValidationAlgorithm):
                 self.tr("Contour value field"),
                 "cota",
                 "INPUT_CONTOURS",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
         self.addParameter(
@@ -116,7 +116,7 @@ class IdentifyErrorsInContourAttributesAlgorithm(ValidationAlgorithm):
         if masterContourExpression is None:
             raise QgsProcessingException(self.tr("invalid expression"))
         self.prepareFlagSink(
-            parameters, inputLyr, QgsWkbTypes.LineString, context, addFeatId=True
+            parameters, inputLyr, QgsWkbTypes.Type.LineString, context, addFeatId=True
         )
         request = QgsFeatureRequest()
         request.setFilterExpression(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGapsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGapsAlgorithm.py
@@ -51,7 +51,7 @@ class IdentifyGapsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Polygon Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -93,7 +93,7 @@ class IdentifyGapsAlgorithm(ValidationAlgorithm):
                 self.invalidSourceError(parameters, self.INPUT)
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Polygon, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Polygon, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         multiStepFeedback = QgsProcessingMultiStepFeedback(4, feedback)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGapsAndOverlapsInCoverageAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGapsAndOverlapsInCoverageAlgorithm.py
@@ -92,7 +92,7 @@ class IdentifyGapsAndOverlapsInCoverageAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Coverage Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
         self.addParameter(
@@ -106,7 +106,7 @@ class IdentifyGapsAndOverlapsInCoverageAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.FRAMELAYER,
                 self.tr("Frame Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -122,7 +122,7 @@ class IdentifyGapsAndOverlapsInCoverageAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.MIN_AREA,
                 self.tr("Minimum error area"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.0,
                 minValue=0.0,
             )
@@ -164,13 +164,15 @@ class IdentifyGapsAndOverlapsInCoverageAlgorithm(ValidationAlgorithm):
         grid_size = self.parameterAsDouble(parameters, self.GRID_SIZE, context)
         min_area = self.parameterAsDouble(parameters, self.MIN_AREA, context)
 
-        self.prepareFlagSink(parameters, input_layers[0], QgsWkbTypes.Polygon, context)
+        self.prepareFlagSink(
+            parameters, input_layers[0], QgsWkbTypes.Type.Polygon, context
+        )
         self.nodeFlagSink, self.node_flag_id = self.parameterAsSink(
             parameters,
             self.NODE_FLAGS,
             context,
             self.getFlagFields(),
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             crs,
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGeometriesWithLargeVertexDensityAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyGeometriesWithLargeVertexDensityAlgorithm.py
@@ -58,7 +58,10 @@ class IdentifyGeometriesWithLargeVertexDensityAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 
@@ -94,7 +97,7 @@ class IdentifyGeometriesWithLargeVertexDensityAlgorithm(ValidationAlgorithm):
         searchRadius = self.parameterAsDouble(parameters, self.SEARCH_RADIUS, context)
         # output flag type is a polygon because the flag will be a circle with
         # radius tol and center as the vertex
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         multiStepFeedback = QgsProcessingMultiStepFeedback(5, feedback)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyIntertwinedLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyIntertwinedLinesAlgorithm.py
@@ -51,14 +51,16 @@ class IdentifyIntertwinedLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input lines"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input lines"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterVectorLayer(
                 self.COMPARE_INPUT,
                 self.tr("Compare lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -66,7 +68,7 @@ class IdentifyIntertwinedLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.TOLERANCE,
                 self.tr("Tolerance"),
-                QgsProcessingParameterNumber.Integer,
+                QgsProcessingParameterNumber.Type.Integer,
             )
         )
 
@@ -86,7 +88,9 @@ class IdentifyIntertwinedLinesAlgorithm(ValidationAlgorithm):
             parameters, self.COMPARE_INPUT, context
         )
         tolerance = self.parameterAsInt(parameters, self.TOLERANCE, context)
-        self.prepareFlagSink(parameters, inputSource, QgsWkbTypes.MultiPoint, context)
+        self.prepareFlagSink(
+            parameters, inputSource, QgsWkbTypes.Type.MultiPoint, context
+        )
         nFeats = inputSource.featureCount()
         nCompareFeats = compareInputSource.featureCount()
         if (
@@ -193,16 +197,16 @@ class IdentifyIntertwinedLinesAlgorithm(ValidationAlgorithm):
             intersections.convertToMultiType()
             if intersections.isEmpty():
                 continue
-            if intersections.wkbType() == QgsWkbTypes.GeometryCollection:
+            if intersections.wkbType() == QgsWkbTypes.Type.GeometryCollection:
                 points = []
                 for intersection in intersections.asGeometryCollection():
-                    if intersection.wkbType() == QgsWkbTypes.LineString:
+                    if intersection.wkbType() == QgsWkbTypes.Type.LineString:
                         points.extend(intersection.asPolyline())
-                    if intersection.wkbType() == QgsWkbTypes.Point:
+                    if intersection.wkbType() == QgsWkbTypes.Type.Point:
                         points.extend([intersection.asPoint()])
                 geom = QgsGeometry()
                 intersections = geom.fromMultiPointXY(points)
-            if intersections.wkbType() == QgsWkbTypes.MultiLineString:
+            if intersections.wkbType() == QgsWkbTypes.Type.MultiLineString:
                 points = []
                 for line in intersections.asMultiPolyline():
                     points.extend(line)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyInvalidSpatialRelationshipAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyInvalidSpatialRelationshipAlgorithm.py
@@ -58,7 +58,7 @@ class IdentifyInvalidSpatialRelationshipAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_A,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyInvalidUUIDsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyInvalidUUIDsAlgorithm.py
@@ -57,7 +57,7 @@ class IdentifyInvalidUUIDsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Input layer(s)"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
 
@@ -183,7 +183,7 @@ class IdentifyInvalidUUIDsAlgorithm(ValidationAlgorithm):
         return {self.OUTPUT: output_dest_id}
 
     def getFlagWkbType(self):
-        return QgsWkbTypes.Point
+        return QgsWkbTypes.Type.Point
 
     def getFlagFields(self):
         sinkFields = QgsFields()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingLineIntersectionsOnPoints.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingLineIntersectionsOnPoints.py
@@ -56,7 +56,7 @@ class IdentifyMissingLineIntersectionsOnPoints(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES_1,
                 self.tr("First Line Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -73,7 +73,7 @@ class IdentifyMissingLineIntersectionsOnPoints(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES_2,
                 self.tr("Second Line Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -90,7 +90,7 @@ class IdentifyMissingLineIntersectionsOnPoints(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_INTERSECTION,
                 self.tr("Intersection Point Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -143,7 +143,7 @@ class IdentifyMissingLineIntersectionsOnPoints(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             inputFirstLineLyr,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             context,
         )
         if feedback is not None:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingLinesOnPolygonLineIntersections.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingLinesOnPolygonLineIntersections.py
@@ -56,7 +56,7 @@ class IdentifyMissingLinesOnPolygonLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES,
                 self.tr("Line Layers"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -73,7 +73,7 @@ class IdentifyMissingLinesOnPolygonLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -90,7 +90,7 @@ class IdentifyMissingLinesOnPolygonLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_INTERSECTION,
                 self.tr("Intersection Lines Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -143,7 +143,7 @@ class IdentifyMissingLinesOnPolygonLineIntersections(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             inputLineLyr,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             context,
         )
         if feedback is not None:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingPointsOnLineIntersections.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingPointsOnLineIntersections.py
@@ -56,7 +56,7 @@ class IdentifyMissingPointsOnLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES_1,
                 self.tr("First Line Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -73,7 +73,7 @@ class IdentifyMissingPointsOnLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES_2,
                 self.tr("Second Line Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -90,7 +90,7 @@ class IdentifyMissingPointsOnLineIntersections(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_INTERSECTION,
                 self.tr("Intersection Point Layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
             )
         )
 
@@ -143,7 +143,7 @@ class IdentifyMissingPointsOnLineIntersections(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             inputFirstLineLyr,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             context,
         )
         if feedback is not None:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingPolygonLinesIntersectionsOnLines.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMissingPolygonLinesIntersectionsOnLines.py
@@ -56,7 +56,7 @@ class IdentifyMissingPolygonLineIntersectionsOnLines(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LINES,
                 self.tr("Line Layers"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -73,7 +73,7 @@ class IdentifyMissingPolygonLineIntersectionsOnLines(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -90,7 +90,7 @@ class IdentifyMissingPolygonLineIntersectionsOnLines(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_INTERSECTION,
                 self.tr("Intersection Lines Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -143,7 +143,7 @@ class IdentifyMissingPolygonLineIntersectionsOnLines(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             inputLineLyr,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             context,
         )
         if feedback is not None:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMultiPartGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyMultiPartGeometriesAlgorithm.py
@@ -48,7 +48,7 @@ class IdentifyMultiPartGeometriesAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input layer"),
                 [
-                    QgsProcessing.TypeVectorAnyGeometry,
+                    QgsProcessing.SourceType.TypeVectorAnyGeometry,
                 ],
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyNetworkConstructionIssuesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyNetworkConstructionIssuesAlgorithm.py
@@ -64,7 +64,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LINES,
                 self.tr("Input lines"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=False,
             )
         )
@@ -87,7 +87,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
                 self.TOLERANCE,
                 self.tr("Search radius"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.0001,
             )
         )
@@ -95,7 +95,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINEFILTERLAYERS,
                 self.tr("Linestring Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -103,7 +103,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGONFILTERLAYERS,
                 self.tr("Polygon Filter Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -119,7 +119,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
                 self.tr(
                     "Geographic Boundary (this layer only filters the output dangles)"
                 ),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -154,7 +154,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
             parameters, self.GEOGRAPHIC_BOUNDARY, context
         )
         refLyr = lineLyrList[0] if len(lineLyrList) > 0 else None
-        self.prepareFlagSink(parameters, refLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, refLyr, QgsWkbTypes.Type.Point, context)
         if refLyr is None:
             return {"FLAGS": self.flag_id}
         multiStepFeedback = QgsProcessingMultiStepFeedback(4, feedback)
@@ -178,7 +178,7 @@ class IdentifyNetworkConstructionIssuesAlgorithm(ValidationAlgorithm):
         multiStepFeedback.setCurrentStep(2)
         if outputLyr.featureCount() > 0:
             self.flagSink.addFeatures(
-                outputLyr.getFeatures(), QgsFeatureSink.FastInsert
+                outputLyr.getFeatures(), QgsFeatureSink.Flag.FastInsert
             )
         multiStepFeedback.setCurrentStep(3)
         self.getUnsegmentedErrors(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOutOfBoundsAnglesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOutOfBoundsAnglesAlgorithm.py
@@ -51,7 +51,10 @@ class IdentifyOutOfBoundsAnglesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 
@@ -85,7 +88,7 @@ class IdentifyOutOfBoundsAnglesAlgorithm(ValidationAlgorithm):
             )
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
         tol = self.parameterAsDouble(parameters, self.TOLERANCE, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         featureList, total = self.getIteratorAndFeatureCount(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOutOfBoundsAnglesInCoverageAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOutOfBoundsAnglesInCoverageAlgorithm.py
@@ -54,7 +54,9 @@ class IdentifyOutOfBoundsAnglesInCoverageAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterMultipleLayers(
-                self.INPUTLAYERS, self.tr("Input layer"), QgsProcessing.TypeVectorLine
+                self.INPUTLAYERS,
+                self.tr("Input layer"),
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -127,12 +129,14 @@ class IdentifyOutOfBoundsAnglesInCoverageAlgorithm(ValidationAlgorithm):
         algRunner = AlgRunner()
         inputLyrList = self.parameterAsLayerList(parameters, self.INPUTLAYERS, context)
         if inputLyrList == []:
-            self.prepareFlagSink(parameters, None, QgsWkbTypes.Point, context)
+            self.prepareFlagSink(parameters, None, QgsWkbTypes.Type.Point, context)
             feedback.pushWarning(self.tr("Empty layer list"))
             return {self.FLAGS: self.flag_id}
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
         tol = self.parameterAsDouble(parameters, self.TOLERANCE, context)
-        self.prepareFlagSink(parameters, inputLyrList[0], QgsWkbTypes.Point, context)
+        self.prepareFlagSink(
+            parameters, inputLyrList[0], QgsWkbTypes.Type.Point, context
+        )
         multiStepFeedback = QgsProcessingMultiStepFeedback(6, feedback)
         currentStep = 0
         # merge all layers into one

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOverlapsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyOverlapsAlgorithm.py
@@ -54,8 +54,8 @@ class IdentifyOverlapsAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input layer"),
                 [
-                    QgsProcessing.TypeVectorLine,
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyPolygonSliverAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyPolygonSliverAlgorithm.py
@@ -59,7 +59,7 @@ class IdentifyPolygonSliverAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Polygons to be checked"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
         self.addParameter(
@@ -77,7 +77,7 @@ class IdentifyPolygonSliverAlgorithm(ValidationAlgorithm):
                 self.RATIO_TOL,
                 self.tr("Tolerance area-perimeter ratio"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=10,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyPolygonUndershoots.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyPolygonUndershoots.py
@@ -56,7 +56,7 @@ class IdentifyPolygonUndershootsAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input"),
                 [
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )
@@ -65,7 +65,7 @@ class IdentifyPolygonUndershootsAlgorithm(ValidationAlgorithm):
                 self.REFERENCE,
                 self.tr("Reference polygons"),
                 [
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )
@@ -74,7 +74,7 @@ class IdentifyPolygonUndershootsAlgorithm(ValidationAlgorithm):
                 self.TOLERANCE,
                 self.tr("Search radius"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.0001,
             )
         )
@@ -91,7 +91,9 @@ class IdentifyPolygonUndershootsAlgorithm(ValidationAlgorithm):
         self.layerHandler = LayerHandler()
         algRunner = AlgRunner()
         inputSource = self.parameterAsSource(parameters, self.INPUT, context)
-        self.prepareFlagSink(parameters, inputSource, QgsWkbTypes.LineString, context)
+        self.prepareFlagSink(
+            parameters, inputSource, QgsWkbTypes.Type.LineString, context
+        )
         if inputSource is None:
             return {"FLAGS": self.flag_id}
         searchRadius = self.parameterAsDouble(parameters, self.TOLERANCE, context)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySegmentErrorsBetweenLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySegmentErrorsBetweenLinesAlgorithm.py
@@ -54,21 +54,23 @@ class IdentifySegmentErrorsBetweenLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterFeatureSource(
-                self.INPUT, self.tr("Input lines"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input lines"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterFeatureSource(
                 self.REFERENCE_LINE,
                 self.tr("Reference lines"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.SEARCH_RADIUS,
                 self.tr("Search Radius"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -88,7 +90,9 @@ class IdentifySegmentErrorsBetweenLinesAlgorithm(ValidationAlgorithm):
             parameters, self.REFERENCE_LINE, context
         )
         searchRadius = self.parameterAsDouble(parameters, self.SEARCH_RADIUS, context)
-        self.prepareFlagSink(parameters, inputSource, QgsWkbTypes.MultiPoint, context)
+        self.prepareFlagSink(
+            parameters, inputSource, QgsWkbTypes.Type.MultiPoint, context
+        )
         nFeats = inputSource.featureCount()
         nReferenceFeats = referenceSource.featureCount()
         if inputSource is None or nFeats == 0 or nReferenceFeats == 0:

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallFirstOrderDangle.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallFirstOrderDangle.py
@@ -52,7 +52,9 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -65,7 +67,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
                 self.MIN_LENGTH,
                 self.tr("Minimum size"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.001,
             )
         )
@@ -74,7 +76,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
                 self.SEARCH_RADIUS,
                 self.tr("Search radius"),
                 minValue=0,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 defaultValue=0.0001,
             )
         )
@@ -82,7 +84,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINEFILTERLAYERS,
                 self.tr("Linestring Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -90,7 +92,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POLYGONFILTERLAYERS,
                 self.tr("Polygon Filter Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -100,7 +102,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
                 self.tr(
                     "Geographic Boundary (this layer only filters the output dangles)"
                 ),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -127,7 +129,7 @@ class IdentifySmallFirstOrderDanglesAlgorithm(ValidationAlgorithm):
         geographicBoundsLyr = self.parameterAsVectorLayer(
             parameters, self.GEOGRAPHIC_BOUNDARY, context
         )
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.LineString, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.LineString, context)
         if inputLyr is None:
             return {self.FLAGS: self.flag_id}
         # Compute the number of steps to display within the progress bar and

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallHolesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallHolesAlgorithm.py
@@ -52,7 +52,7 @@ class IdentifySmallHolesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 "INPUT_LAYER_LIST",
                 self.tr("Input layer(s)"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
 
@@ -60,7 +60,7 @@ class IdentifySmallHolesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 "MAX_HOLE_SIZE",
                 self.tr("Tolerance"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
             )
         )
@@ -83,7 +83,12 @@ class IdentifySmallHolesAlgorithm(ValidationAlgorithm):
         newField = QgsFields()
         newField.append(QgsField("area", QMetaType.Type.Double))
         (self.sink, self.sink_id) = self.parameterAsSink(
-            parameters, self.OUTPUT, context, newField, QgsWkbTypes.MultiPolygon, crs
+            parameters,
+            self.OUTPUT,
+            context,
+            newField,
+            QgsWkbTypes.Type.MultiPolygon,
+            crs,
         )
         for step, layer in enumerate(layerList):
             if feedback.isCanceled():
@@ -114,7 +119,7 @@ class IdentifySmallHolesAlgorithm(ValidationAlgorithm):
             newFeat.setGeometry(feature)
             newFeat.setFields(newField)
             newFeat["area"] = feature.area()
-            self.sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            self.sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def name(self):
         """

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallLinesAlgorithm.py
@@ -46,7 +46,9 @@ class IdentifySmallLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -60,7 +62,7 @@ class IdentifySmallLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.TOLERANCE,
                 self.tr("Line length tolerance"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=5,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallObjectsOnLayersAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallObjectsOnLayersAlgorithm.py
@@ -99,14 +99,14 @@ class IdentifySmallObjectsOnLayersAlgorithm(ValidationAlgorithm):
         (self.lineFlagSink, self.line_flag_id) = self.prepareAndReturnFlagSink(
             parameters,
             None,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             context,
             self.LINE_FLAGS,
         )
         (self.polygonFlagSink, self.polygon_flag_id) = self.prepareAndReturnFlagSink(
             parameters,
             None,
-            QgsWkbTypes.Polygon,
+            QgsWkbTypes.Type.Polygon,
             context,
             self.POLYGON_FLAGS,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallPolygonsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifySmallPolygonsAlgorithm.py
@@ -47,7 +47,9 @@ class IdentifySmallPolygonsAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorPolygon]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -61,7 +63,7 @@ class IdentifySmallPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.TOLERANCE,
                 self.tr("Area tolerance"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=625,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyTerrainModelErrorsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyTerrainModelErrorsAlgorithm.py
@@ -70,7 +70,7 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input contour layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 defaultValue="elemnat_curva_nivel_l",
             )
         )
@@ -85,7 +85,7 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
                 self.tr("Contour value field"),
                 "cota",
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
         self.addParameter(
@@ -101,7 +101,7 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_SPOT_ELEVATION,
                 self.tr("Input spot elevation layer"),
-                [QgsProcessing.TypeVectorPoint],
+                [QgsProcessing.SourceType.TypeVectorPoint],
                 optional=True,
             )
         )
@@ -111,7 +111,7 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
                 self.tr("Spot elevation height value field"),
                 "cota",
                 self.INPUT_SPOT_ELEVATION,
-                QgsProcessingParameterField.Numeric,
+                QgsProcessingParameterField.DataType.Numeric,
                 optional=True,
             )
         )
@@ -124,7 +124,7 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDS,
                 self.tr("Geographic bounds layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
                 defaultValue="aux_moldura_a",
             )
@@ -200,13 +200,13 @@ class IdentifyTerrainModelErrorsAlgorithm(ValidationAlgorithm):
                 self.tr("Spot elevation height attribute must be selected.")
             )
         point_flagSink, point_flag_sink_id = self.prepareAndReturnFlagSink(
-            parameters, inputLyr, QgsWkbTypes.Point, context, self.POINT_FLAGS
+            parameters, inputLyr, QgsWkbTypes.Type.Point, context, self.POINT_FLAGS
         )
         line_flagSink, line_flag_sink_id = self.prepareAndReturnFlagSink(
-            parameters, inputLyr, QgsWkbTypes.LineString, context, self.LINE_FLAGS
+            parameters, inputLyr, QgsWkbTypes.Type.LineString, context, self.LINE_FLAGS
         )
         polygon_flagSink, polygon_flag_sink_id = self.prepareAndReturnFlagSink(
-            parameters, inputLyr, QgsWkbTypes.Polygon, context, self.POLYGON_FLAGS
+            parameters, inputLyr, QgsWkbTypes.Type.Polygon, context, self.POLYGON_FLAGS
         )
 
         sinkDict = {

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUncoveredStartAndEndPointsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUncoveredStartAndEndPointsAlgorithm.py
@@ -56,7 +56,7 @@ class IdentifyUncoveredStartAndEndPointsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -80,7 +80,7 @@ class IdentifyUncoveredStartAndEndPointsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.FILTER_LINE_LIST,
                 self.tr("Linestring Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -88,7 +88,7 @@ class IdentifyUncoveredStartAndEndPointsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -106,7 +106,7 @@ class IdentifyUncoveredStartAndEndPointsAlgorithm(ValidationAlgorithm):
         """
         self.algRunner = AlgRunner()
         inputLyr = self.parameterAsLayer(parameters, self.INPUT, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         if inputLyr is None:
             return {self.FLAGS: self.flag_id}
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnmergedLinesWithSameAttributeSetAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnmergedLinesWithSameAttributeSetAlgorithm.py
@@ -64,7 +64,7 @@ class IdentifyUnmergedLinesWithSameAttributeSetAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input layer"),
                 [
-                    QgsProcessing.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorLine,
                 ],
             )
         )
@@ -79,7 +79,7 @@ class IdentifyUnmergedLinesWithSameAttributeSetAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -102,7 +102,7 @@ class IdentifyUnmergedLinesWithSameAttributeSetAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_FILTER_LAYERS,
                 self.tr("Point Filter Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -110,7 +110,7 @@ class IdentifyUnmergedLinesWithSameAttributeSetAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_FILTER_LAYERS,
                 self.tr("Line Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -142,7 +142,7 @@ class IdentifyUnmergedLinesWithSameAttributeSetAlgorithm(ValidationAlgorithm):
         lineFilterLyrList = self.parameterAsLayerList(
             parameters, self.LINE_FILTER_LAYERS, context
         )
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         if inputLyr is None or inputLyr.featureCount() == 0:
             return {"FLAGS": self.flag_id}
         attributeBlackList = self.parameterAsStrings(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnmergedPolygonsWithSameAttributeSetAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnmergedPolygonsWithSameAttributeSetAlgorithm.py
@@ -67,7 +67,7 @@ class IdentifyUnmergedPolygonsWithSameAttributeSetAlgorithm(ValidationAlgorithm)
                 self.INPUT,
                 self.tr("Input layer"),
                 [
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )
@@ -82,7 +82,7 @@ class IdentifyUnmergedPolygonsWithSameAttributeSetAlgorithm(ValidationAlgorithm)
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -105,14 +105,14 @@ class IdentifyUnmergedPolygonsWithSameAttributeSetAlgorithm(ValidationAlgorithm)
             QgsProcessingParameterMultipleLayers(
                 self.LINE_FILTER_LAYERS,
                 self.tr("Line Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
         areaFilter = QgsProcessingParameterNumber(
             self.AREA_FILTER,
             self.tr("Minimum area polygon filter"),
-            QgsProcessingParameterNumber.Double,
+            QgsProcessingParameterNumber.Type.Double,
             defaultValue=None,
             optional=True,
             minValue=0.0,
@@ -139,7 +139,7 @@ class IdentifyUnmergedPolygonsWithSameAttributeSetAlgorithm(ValidationAlgorithm)
         lineFilterLyrList = self.parameterAsLayerList(
             parameters, self.LINE_FILTER_LAYERS, context
         )
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.LineString, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.LineString, context)
         if inputLyr is None or inputLyr.featureCount() == 0:
             return {"FLAGS": self.flag_id}
         attributeBlackList = self.parameterAsStrings(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnsharedVertexOnIntersectionsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnsharedVertexOnIntersectionsAlgorithm.py
@@ -52,7 +52,7 @@ class IdentifyUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POINTS,
                 self.tr("Point Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -60,7 +60,7 @@ class IdentifyUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LINES,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -68,7 +68,7 @@ class IdentifyUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -105,7 +105,7 @@ class IdentifyUnsharedVertexOnIntersectionsAlgorithm(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             (inputPointLyrList + inputLineLyrList + inputPolygonLyrList)[0],
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             context,
         )
         # Compute the number of steps to display within the progress bar and

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnsharedVertexOnSharedEdgesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyUnsharedVertexOnSharedEdgesAlgorithm.py
@@ -54,7 +54,7 @@ class IdentifyUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LINES,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -62,7 +62,7 @@ class IdentifyUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -103,7 +103,7 @@ class IdentifyUnsharedVertexOnSharedEdgesAlgorithm(ValidationAlgorithm):
         self.prepareFlagSink(
             parameters,
             (inputLineLyrList + inputPolygonLyrList)[0],
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             context,
         )
         # Compute the number of steps to display within the progress bar and

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyVertexNearEdgesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyVertexNearEdgesAlgorithm.py
@@ -52,7 +52,10 @@ class IdentifyVertexNearEdgesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorLine, QgsProcessing.TypeVectorPolygon],
+                [
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
+                ],
             )
         )
 
@@ -88,7 +91,7 @@ class IdentifyVertexNearEdgesAlgorithm(ValidationAlgorithm):
         searchRadius = self.parameterAsDouble(parameters, self.SEARCH_RADIUS, context)
         # output flag type is a polygon because the flag will be a circle with
         # radius tol and center as the vertex
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         multiStepFeedback = QgsProcessingMultiStepFeedback(2, feedback)

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyWaterBodyAndContourInconsistencies.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyWaterBodyAndContourInconsistencies.py
@@ -52,7 +52,7 @@ class IdentifyWaterBodyAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_WATER_BODIES,
                 self.tr("Input water bodies"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=False,
                 defaultValue="cobter_massa_dagua_a",
             )
@@ -62,7 +62,7 @@ class IdentifyWaterBodyAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT_CONTOURS,
                 self.tr("Input contours"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=False,
                 defaultValue="elemnat_curva_nivel_l",
             )
@@ -74,7 +74,7 @@ class IdentifyWaterBodyAndContourInconsistencies(ValidationAlgorithm):
                 self.tr("Contour value field"),
                 "cota",
                 self.INPUT_CONTOURS,
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
             )
         )
 
@@ -91,7 +91,7 @@ class IdentifyWaterBodyAndContourInconsistencies(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.DAM_LAYER,
                 self.tr("Dam Layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=True,
                 defaultValue="infra_barragem_l",
             )
@@ -116,7 +116,9 @@ class IdentifyWaterBodyAndContourInconsistencies(ValidationAlgorithm):
             parameters, self.INPUT_WATER_BODIES, context
         )
         damLyr = self.parameterAsVectorLayer(parameters, self.DAM_LAYER, context)
-        self.prepareFlagSink(parameters, inputContours, QgsWkbTypes.LineString, context)
+        self.prepareFlagSink(
+            parameters, inputContours, QgsWkbTypes.Type.LineString, context
+        )
         currentStep = 0
         multiStepFeedback.setCurrentStep(currentStep)
         if (

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyWrongBuildingAnglesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyWrongBuildingAnglesAlgorithm.py
@@ -51,7 +51,9 @@ class IdentifyWrongBuildingAnglesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorPolygon]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -66,7 +68,7 @@ class IdentifyWrongBuildingAnglesAlgorithm(ValidationAlgorithm):
                 self.tr("Angular tolerance in decimal degrees"),
                 minValue=0,
                 defaultValue=0.1,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -96,7 +98,7 @@ class IdentifyWrongBuildingAnglesAlgorithm(ValidationAlgorithm):
         onlySelected = self.parameterAsBool(parameters, self.SELECTED, context)
         tol = self.parameterAsDouble(parameters, self.TOLERANCE, context)
         ignoreCircles = self.parameterAsBool(parameters, self.IGNORE_CIRCLES, context)
-        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Point, context)
+        self.prepareFlagSink(parameters, inputLyr, QgsWkbTypes.Type.Point, context)
         # Compute the number of steps to display within the progress bar and
         # get features from source
         featureList, total = self.getIteratorAndFeatureCount(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyZAnglesBetweenFeaturesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/identifyZAnglesBetweenFeaturesAlgorithm.py
@@ -59,8 +59,8 @@ class IdentifyZAnglesBetweenFeaturesAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input"),
                 [
-                    QgsProcessing.TypeVectorLine,
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )
@@ -68,7 +68,7 @@ class IdentifyZAnglesBetweenFeaturesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.ANGLE,
                 self.tr("Minimum angle"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 defaultValue=300,
                 minValue=270,
                 maxValue=360,
@@ -88,7 +88,12 @@ class IdentifyZAnglesBetweenFeaturesAlgorithm(ValidationAlgorithm):
         self.fields.append(QgsField("source", QMetaType.Type.QString))
 
         sink, dest_id = self.parameterAsSink(
-            parameters, self.OUTPUT, context, self.fields, QgsWkbTypes.LineString, crs
+            parameters,
+            self.OUTPUT,
+            context,
+            self.fields,
+            QgsWkbTypes.Type.LineString,
+            crs,
         )
 
         # Initialize caches
@@ -354,7 +359,7 @@ class IdentifyZAnglesBetweenFeaturesAlgorithm(ValidationAlgorithm):
 
             # Check if intersection forms a valid Z angle
             intersection = gfeat1.intersection(gfeat2)
-            if intersection.wkbType() == QgsWkbTypes.Point:
+            if intersection.wkbType() == QgsWkbTypes.Type.Point:
                 # Get closest vertices to intersection
                 intersection_point = intersection.asPoint()
 
@@ -551,8 +556,8 @@ class IdentifyZAnglesBetweenFeaturesAlgorithm(ValidationAlgorithm):
 
         # Verify intersections are valid points
         if (
-            inter12.wkbType() != QgsWkbTypes.Point
-            or inter23.wkbType() != QgsWkbTypes.Point
+            inter12.wkbType() != QgsWkbTypes.Type.Point
+            or inter23.wkbType() != QgsWkbTypes.Type.Point
         ):
             return []
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/mergeLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/mergeLinesAlgorithm.py
@@ -60,7 +60,9 @@ class MergeLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(
@@ -74,7 +76,7 @@ class MergeLinesAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )
@@ -104,7 +106,7 @@ class MergeLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.POINT_FILTER_LAYERS,
                 self.tr("Point Filter Layers"),
-                QgsProcessing.TypeVectorPoint,
+                QgsProcessing.SourceType.TypeVectorPoint,
                 optional=True,
             )
         )
@@ -112,7 +114,7 @@ class MergeLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.LINE_FILTER_LAYERS,
                 self.tr("Line Filter Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -120,7 +122,7 @@ class MergeLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/overlayElementsWithAreasAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/overlayElementsWithAreasAlgorithm.py
@@ -52,7 +52,7 @@ class OverlayElementsWithAreasAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -64,7 +64,7 @@ class OverlayElementsWithAreasAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.OVERLAY,
                 self.tr("Polygon overlay Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/overlayLinesWithLinesAndUpdate.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/overlayLinesWithLinesAndUpdate.py
@@ -61,7 +61,7 @@ class OverlayLinesWithLinesAndUpdate(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input line layer"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -76,7 +76,7 @@ class OverlayLinesWithLinesAndUpdate(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.REFERENCE_LINES,
                 self.tr("Reference line layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -84,7 +84,7 @@ class OverlayLinesWithLinesAndUpdate(QgsProcessingAlgorithm):
         param = QgsProcessingParameterNumber(
             self.SNAP_TOLERANCE,
             self.tr("Snap tolerance for vertex insertion"),
-            QgsProcessingParameterNumber.Double,
+            QgsProcessingParameterNumber.Type.Double,
             defaultValue=0.001,
             minValue=0.0,
             optional=True,
@@ -96,7 +96,7 @@ class OverlayLinesWithLinesAndUpdate(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Bounds Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -173,7 +173,7 @@ class OverlayLinesWithLinesAndUpdate(QgsProcessingAlgorithm):
         multiStepFeedback.setCurrentStep(currentStep)
         auxReferenceLyr = self.layerHandler.createAndPopulateUnifiedVectorLayer(
             referenceLyrList,
-            geomType=QgsWkbTypes.MultiLineString,
+            geomType=QgsWkbTypes.Type.MultiLineString,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicateNodesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicateNodesAlgorithm.py
@@ -49,7 +49,7 @@ class RemoveDuplicateVertexesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input Layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicatedFeaturesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicatedFeaturesAlgorithm.py
@@ -49,7 +49,7 @@ class RemoveDuplicatedFeaturesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -65,7 +65,7 @@ class RemoveDuplicatedFeaturesAlgorithm(ValidationAlgorithm):
                 self.tr("Fields to ignore"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=True,
                 optional=True,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicatedGeometriesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeDuplicatedGeometriesAlgorithm.py
@@ -48,7 +48,7 @@ class RemoveDuplicatedGeometriesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeEmptyAndUpdateAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeEmptyAndUpdateAlgorithm.py
@@ -47,7 +47,7 @@ class RemoveEmptyAndUpdateAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeSmallLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeSmallLinesAlgorithm.py
@@ -44,7 +44,9 @@ class RemoveSmallLinesAlgorithm(ValidationAlgorithm):
         """
         self.addParameter(
             QgsProcessingParameterVectorLayer(
-                self.INPUT, self.tr("Input layer"), [QgsProcessing.TypeVectorLine]
+                self.INPUT,
+                self.tr("Input layer"),
+                [QgsProcessing.SourceType.TypeVectorLine],
             )
         )
 
@@ -58,7 +60,7 @@ class RemoveSmallLinesAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.TOLERANCE,
                 self.tr("Line length tolerance"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=5,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeSmallPolygonsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/removeSmallPolygonsAlgorithm.py
@@ -47,7 +47,7 @@ class RemoveSmallPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -61,7 +61,7 @@ class RemoveSmallPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.TOLERANCE,
                 self.tr("Area tolerance"),
-                QgsProcessingParameterNumber.Double,
+                QgsProcessingParameterNumber.Type.Double,
                 minValue=0,
                 defaultValue=625,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapFeaturesInsideLayerWithGroupByAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapFeaturesInsideLayerWithGroupByAlgorithm.py
@@ -52,7 +52,7 @@ class SnapFeaturesInsideLayerWithGroupByAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -67,7 +67,7 @@ class SnapFeaturesInsideLayerWithGroupByAlgorithm(ValidationAlgorithm):
                 self.tr("Field to group by"),
                 None,
                 "INPUT",
-                QgsProcessingParameterField.Any,
+                QgsProcessingParameterField.DataType.Any,
                 allowMultiple=False,
                 optional=False,
             )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapLayerOnLayerAndUpdateAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapLayerOnLayerAndUpdateAlgorithm.py
@@ -55,7 +55,7 @@ class SnapLayerOnLayerAndUpdateAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(
@@ -68,7 +68,7 @@ class SnapLayerOnLayerAndUpdateAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.REFERENCE_LAYER,
                 self.tr("Reference layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         param = QgsProcessingParameterDistance(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapToGridAndUpdateAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/snapToGridAndUpdateAlgorithm.py
@@ -50,7 +50,7 @@ class SnapToGridAndUpdateAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT,
                 self.tr("Input layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/spellCheckerAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/spellCheckerAlgorithm.py
@@ -34,7 +34,7 @@ class SpellCheckerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_LAYER,
                 self.tr("Layer"),
-                [QgsProcessing.TypeVectorAnyGeometry],
+                [QgsProcessing.SourceType.TypeVectorAnyGeometry],
             )
         )
 
@@ -42,7 +42,7 @@ class SpellCheckerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.ATTRIBUTE_NAME,
                 self.tr("Attribute name"),
-                type=QgsProcessingParameterField.String,
+                type=QgsProcessingParameterField.DataType.String,
                 parentLayerParameterName=self.INPUT_LAYER,
                 allowMultiple=False,
                 defaultValue="nome",
@@ -53,7 +53,7 @@ class SpellCheckerAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterField(
                 self.PRIMARY_KEY_FIELD,
                 self.tr("Primary key field"),
-                type=QgsProcessingParameterField.Any,
+                type=QgsProcessingParameterField.DataType.Any,
                 parentLayerParameterName=self.INPUT_LAYER,
                 allowMultiple=False,
                 defaultValue="id",
@@ -83,7 +83,7 @@ class SpellCheckerAlgorithm(QgsProcessingAlgorithm):
             self.FLAGS,
             context,
             fields,
-            geometryType=QgsWkbTypes.NoGeometry,
+            geometryType=QgsWkbTypes.Type.NoGeometry,
         )
         try:
             spellchecker = SpellCheckerCtrl("pt-BR")
@@ -160,7 +160,7 @@ class SpellCheckerAlgorithm(QgsProcessingAlgorithm):
         return -1
 
     def getFlagWkbType(self):
-        return QgsWkbTypes.Point
+        return QgsWkbTypes.Type.Point
 
     def getFlagFields(self):
         sinkFields = QgsFields()

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/splitContoursAtMaximumLengthAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/splitContoursAtMaximumLengthAlgorithm.py
@@ -50,7 +50,7 @@ class SplitContoursAtMaximumLengthAlgorithm(ValidationAlgorithm):
                 self.INPUT,
                 self.tr("Input contour layer"),
                 defaultValue="elemnat_curva_nivel_l",
-                types=[QgsProcessing.TypeVectorLine],
+                types=[QgsProcessing.SourceType.TypeVectorLine],
             )
         )
         self.addParameter(

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/streamOrder.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/streamOrder.py
@@ -45,7 +45,7 @@ class StreamOrder(QgsProcessingAlgorithm):
             QgsProcessingParameterFeatureSource(
                 self.INPUT,
                 self.tr("Input network"),
-                [QgsProcessing.TypeVectorLine],
+                [QgsProcessing.SourceType.TypeVectorLine],
                 optional=False,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalCleanAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalCleanAlgorithm.py
@@ -55,7 +55,7 @@ class TopologicalCleanAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
 
@@ -70,7 +70,7 @@ class TopologicalCleanAlgorithm(ValidationAlgorithm):
             self.tr("Snap radius"),
             minValue=0,
             defaultValue=1,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         snapParam.setMetadata({"widget_wrapper": {"decimals": 16}})
         self.addParameter(snapParam)
@@ -80,7 +80,7 @@ class TopologicalCleanAlgorithm(ValidationAlgorithm):
             self.tr("Minimum area"),
             minValue=0,
             defaultValue=1e-8,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         areaParam.setMetadata({"widget_wrapper": {"decimals": 16}})
         self.addParameter(areaParam)
@@ -89,7 +89,7 @@ class TopologicalCleanAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Bounds Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalCleanLinesAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalCleanLinesAlgorithm.py
@@ -51,7 +51,7 @@ class TopologicalCleanLinesAlgorithm(TopologicalCleanAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
 
@@ -66,7 +66,7 @@ class TopologicalCleanLinesAlgorithm(TopologicalCleanAlgorithm):
             self.tr("Snap radius"),
             minValue=0,
             defaultValue=1,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         snapParam.setMetadata({"widget_wrapper": {"decimals": 16}})
         self.addParameter(snapParam)
@@ -76,7 +76,7 @@ class TopologicalCleanLinesAlgorithm(TopologicalCleanAlgorithm):
             self.tr("Minimum area"),
             minValue=0,
             defaultValue=1e-8,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         areaParam.setMetadata({"widget_wrapper": {"decimals": 16}})
         self.addParameter(areaParam)
@@ -85,7 +85,7 @@ class TopologicalCleanLinesAlgorithm(TopologicalCleanAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Bounds Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalDouglasAreaSimplificationAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalDouglasAreaSimplificationAlgorithm.py
@@ -59,7 +59,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
         self.addParameter(
@@ -73,7 +73,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
                 self.tr("Douglas Deucker threshold"),
                 minValue=0,
                 defaultValue=2,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -82,7 +82,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
                 self.tr("Snap radius"),
                 minValue=0,
                 defaultValue=1,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -91,7 +91,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
                 self.tr("Minimum area"),
                 minValue=0,
                 defaultValue=0.0001,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         self.addParameter(
@@ -117,7 +117,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
         threshold = self.parameterAsDouble(parameters, self.DOUGLASPARAMETER, context)
         minArea = self.parameterAsDouble(parameters, self.MINAREA, context)
         self.prepareFlagSink(
-            parameters, inputLyrList[0], QgsWkbTypes.MultiPolygon, context
+            parameters, inputLyrList[0], QgsWkbTypes.Type.MultiPolygon, context
         )
 
         multiStepFeedback = QgsProcessingMultiStepFeedback(3, feedback)
@@ -125,7 +125,7 @@ class TopologicalDouglasPeuckerAreaSimplificationAlgorithm(ValidationAlgorithm):
         multiStepFeedback.pushInfo(self.tr("Building unified layer..."))
         coverage = layerHandler.createAndPopulateUnifiedVectorLayer(
             inputLyrList,
-            geomType=QgsWkbTypes.MultiPolygon,
+            geomType=QgsWkbTypes.Type.MultiPolygon,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalDouglasLineSimplificationAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalDouglasLineSimplificationAlgorithm.py
@@ -60,7 +60,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUTLAYERS,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
         self.addParameter(
@@ -74,7 +74,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
                 self.tr("Douglas Deucker threshold"),
                 minValue=0,
                 defaultValue=2,
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
             )
         )
         param = QgsProcessingParameterNumber(
@@ -82,7 +82,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
             self.tr("Snap radius"),
             minValue=0,
             defaultValue=1,
-            type=QgsProcessingParameterNumber.Double,
+            type=QgsProcessingParameterNumber.Type.Double,
         )
         param.setMetadata({"widget_wrapper": {"decimals": 8}})
         self.addParameter(param)
@@ -91,7 +91,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Bounds Layer"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -121,7 +121,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
             parameters, self.GEOGRAPHIC_BOUNDARY, context
         )
         self.prepareFlagSink(
-            parameters, inputLyrList[0], QgsWkbTypes.MultiLineString, context
+            parameters, inputLyrList[0], QgsWkbTypes.Type.MultiLineString, context
         )
 
         if geographicBoundsLyr is None:
@@ -166,7 +166,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
         multiStepFeedback.pushInfo(self.tr("Building unified layer..."))
         coverage = layerHandler.createAndPopulateUnifiedVectorLayer(
             inputLyrList,
-            geomType=QgsWkbTypes.MultiLineString,
+            geomType=QgsWkbTypes.Type.MultiLineString,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,
         )
@@ -235,7 +235,7 @@ class TopologicalDouglasPeuckerLineSimplificationAlgorithm(ValidationAlgorithm):
         multiStepFeedback.pushInfo(self.tr("Building unified layer..."))
         auxLyr = layerHandler.createAndPopulateUnifiedVectorLayer(
             inputLyrList,
-            geomType=QgsWkbTypes.MultiLineString,
+            geomType=QgsWkbTypes.Type.MultiLineString,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalLineConnectivityAdjustmentAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/topologicalLineConnectivityAdjustmentAlgorithm.py
@@ -55,7 +55,7 @@ class TopologicalLineConnectivityAdjustment(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_LAYERS,
                 self.tr("Linestring Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
             )
         )
         self.addParameter(
@@ -92,7 +92,7 @@ class TopologicalLineConnectivityAdjustment(ValidationAlgorithm):
         multiStepFeedback.pushInfo(self.tr("Building unified layer..."))
         coverage = layerHandler.createAndPopulateUnifiedVectorLayer(
             inputLyrList,
-            geomType=QgsWkbTypes.MultiLineString,
+            geomType=QgsWkbTypes.Type.MultiLineString,
             onlySelected=onlySelected,
             feedback=multiStepFeedback,
         )

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/unbuildPolygonsAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/unbuildPolygonsAlgorithm.py
@@ -69,7 +69,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.INPUT_POLYGONS,
                 self.tr("Polygon Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
             )
         )
         self.addParameter(
@@ -81,7 +81,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.CONSTRAINT_LINE_LAYERS,
                 self.tr("Line Constraint Layers"),
-                QgsProcessing.TypeVectorLine,
+                QgsProcessing.SourceType.TypeVectorLine,
                 optional=True,
             )
         )
@@ -89,7 +89,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 self.CONSTRAINT_POLYGON_LAYERS,
                 self.tr("Polygon Constraint Layers"),
-                QgsProcessing.TypeVectorPolygon,
+                QgsProcessing.SourceType.TypeVectorPolygon,
                 optional=True,
             )
         )
@@ -97,7 +97,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.GEOGRAPHIC_BOUNDARY,
                 self.tr("Geographic Boundary"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
                 optional=True,
             )
         )
@@ -163,7 +163,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             self.OUTPUT_CENTER_POINTS,
             context,
             outputSinkFields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             singleInputPolygonBoundariesLayer.sourceCrs(),
         )
         (output_boundaries_sink, output_boundaries_sink_id) = self.parameterAsSink(
@@ -171,7 +171,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
             self.OUTPUT_BOUNDARIES,
             context,
             QgsFields(),
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             singleInputPolygonBoundariesLayer.sourceCrs(),
         )
         if singleInputPolygonBoundariesLayer.featureCount() == 0:
@@ -463,7 +463,7 @@ class UnbuildPolygonsAlgorithm(ValidationAlgorithm):
                     continue
                 newFeat[field.name()] = feat[field.name()]
             newFeat.setGeometry(feat.geometry())
-            output_center_point_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            output_center_point_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
         count = 0
         for feat in final_result_lyr.getFeatures():

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/unicodeFilterAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/unicodeFilterAlgorithm.py
@@ -34,7 +34,7 @@ class UnicodeFilterAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterMultipleLayers(
                 "INPUT_LAYER_LIST",
                 self.tr("Select layers"),
-                QgsProcessing.TypeVectorAnyGeometry,
+                QgsProcessing.SourceType.TypeVectorAnyGeometry,
             )
         )
         self.addParameter(
@@ -118,7 +118,9 @@ class UnicodeFilterAlgorithm(QgsProcessingAlgorithm):
                 newFeat = QgsFeature(fields)
                 newFeat.setGeometry(feat.geometry())
                 newFeat["id"] = idx
-                sinkDict[geometryType].addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sinkDict[geometryType].addFeature(
+                    newFeat, QgsFeatureSink.Flag.FastInsert
+                )
 
         return returnDict
 
@@ -126,19 +128,19 @@ class UnicodeFilterAlgorithm(QgsProcessingAlgorithm):
         returnDict = dict()
         sinkDict = dict()
         point_sink, point_sink_id = self.createOutput(
-            parameters, context, self.OUTPUT1, QgsWkbTypes.MultiPoint, fields
+            parameters, context, self.OUTPUT1, QgsWkbTypes.Type.MultiPoint, fields
         )
         returnDict[self.OUTPUT1] = point_sink_id
         sinkDict[Qgis.GeometryType.Point] = point_sink
 
         line_sink, line_sink_id = self.createOutput(
-            parameters, context, self.OUTPUT2, QgsWkbTypes.MultiLineString, fields
+            parameters, context, self.OUTPUT2, QgsWkbTypes.Type.MultiLineString, fields
         )
         returnDict[self.OUTPUT2] = line_sink_id
         sinkDict[Qgis.GeometryType.Line] = line_sink
 
         polygon_sink, polygon_sink_id = self.createOutput(
-            parameters, context, self.OUTPUT3, QgsWkbTypes.MultiPolygon, fields
+            parameters, context, self.OUTPUT3, QgsWkbTypes.Type.MultiPolygon, fields
         )
         returnDict[self.OUTPUT3] = polygon_sink_id
         sinkDict[Qgis.GeometryType.Polygon] = polygon_sink

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/validationAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/validationAlgorithm.py
@@ -105,7 +105,7 @@ class ValidationAlgorithm(QgsProcessingAlgorithm):
             newFeat.setGeometry(geom)
         else:
             newFeat.setGeometry(flagGeom)
-        flagSink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+        flagSink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def getFlagsFromOutput(self, output):
         if "FLAGS" not in output:
@@ -115,7 +115,7 @@ class ValidationAlgorithm(QgsProcessingAlgorithm):
     def flagFeaturesFromProcessOutput(self, output):
         if "FLAGS" in output:
             for feat in output["FLAGS"].getFeatures():
-                self.flagSink.addFeature(feat, QgsFeatureSink.FastInsert)
+                self.flagSink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
     def getLayerFromProject(self, layerName):
         """

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/verifyAdjacentGeographicBoundaryDataAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/verifyAdjacentGeographicBoundaryDataAlgorithm.py
@@ -60,8 +60,8 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
                 self.INPUT_LINE_POLYGON,
                 self.tr("Input layer"),
                 [
-                    QgsProcessing.TypeVectorLine,
-                    QgsProcessing.TypeVectorPolygon,
+                    QgsProcessing.SourceType.TypeVectorLine,
+                    QgsProcessing.SourceType.TypeVectorPolygon,
                 ],
             )
         )
@@ -70,7 +70,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterVectorLayer(
                 self.INPUT_FRAME,
                 self.tr("Input frame"),
-                [QgsProcessing.TypeVectorPolygon],
+                [QgsProcessing.SourceType.TypeVectorPolygon],
             )
         )
 
@@ -126,7 +126,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
             self.POINT_FLAGS,
             context,
             fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             inputLinePolyLyr.sourceCrs(),
         )
 
@@ -135,7 +135,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
             self.LINE_FLAGS,
             context,
             fields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             inputLinePolyLyr.sourceCrs(),
         )
 
@@ -374,7 +374,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
             newFeat = QgsFeature(fields)
             newFeat.setGeometry(vtxFlag)
             newFeat["flag"] = self.tr("Polygon is incorrectly connected.")
-            point_flag_sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+            point_flag_sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     def linesBuffFrame(
         self,
@@ -460,7 +460,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
             if lenIdSet == 1:
                 newFeat.setGeometry(line)
                 newFeat["Flag"] = self.tr("Polygons not correctly connected.")
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
             elif lenIdSet == 2:
                 [id1, id2] = list(dictLinePoly[bbGeomWkt])
                 feat1 = dictExplodeLinePoly[id1]
@@ -475,11 +475,11 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
                     newFeat["Flag"] = self.tr(
                         "Polygons do not have matching attributes {0}."
                     ).format(msg[: len(msg) - 2])
-                    sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                    sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
             else:
                 newFeat.setGeometry(line)
                 newFeat["Flag"] = self.tr("More than 2 polygons connected.")
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
             feed.setProgress(current * stepSize)
         return listLines
@@ -586,7 +586,7 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
                 geomVertFlag = dictVertInFrame[wktSpecifVert][0].geometry()
                 newFeat.setGeometry(geomVertFlag)
                 newFeat["Flag"] = self.tr("No connection at the frame")
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
             elif len(dictVertInFrame[wktSpecifVert]) == 2:
                 [vertFeatOne, vertFeatTwo] = dictVertInFrame[wktSpecifVert]
                 dictAttrFeat = defaultdict(set)
@@ -605,12 +605,12 @@ class VerifyAdjacentGeographicBoundaryDataAlgorithm(ValidationAlgorithm):
                 newFeat["Flag"] = self.tr("Attributes {0} are different.").format(
                     ", ".join(diffAttrs)
                 )
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
             else:
                 geomVertFlag = dictVertInFrame[wktSpecifVert][0].geometry()
                 newFeat.setGeometry(geomVertFlag)
                 newFeat["Flag"] = self.tr("Three or more roads connected.")
-                sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+                sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
             feed.setProgress(current * stepSize)
 

--- a/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/verifyBDGExEdgeMatchingAlgorithm.py
+++ b/DsgTools/core/DSGToolsProcessingAlgs/Algs/ValidationAlgs/verifyBDGExEdgeMatchingAlgorithm.py
@@ -73,7 +73,7 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterFile(
                 self.ZIP_FOLDER,
                 self.tr("Folder with BDGEx zip files"),
-                behavior=QgsProcessingParameterFile.Folder,
+                behavior=QgsProcessingParameterFile.Behavior.Folder,
             )
         )
 
@@ -91,7 +91,7 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
             QgsProcessingParameterNumber(
                 self.SEARCH_RADIUS,
                 self.tr("Search radius"),
-                type=QgsProcessingParameterNumber.Double,
+                type=QgsProcessingParameterNumber.Type.Double,
                 minValue=0.0,
                 defaultValue=0.0001,
             )
@@ -169,7 +169,7 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
             self.POINT_FLAGS,
             context,
             fields,
-            QgsWkbTypes.Point,
+            QgsWkbTypes.Type.Point,
             refCrs,
         )
         if pointFlagSink is None:
@@ -182,7 +182,7 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
             self.LINE_FLAGS,
             context,
             fields,
-            QgsWkbTypes.LineString,
+            QgsWkbTypes.Type.LineString,
             refCrs,
         )
         if lineFlagSink is None:
@@ -640,9 +640,9 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
         """
         flatType = QgsWkbTypes.flatType(geom.wkbType())
         rings = []
-        if flatType == QgsWkbTypes.Polygon:
+        if flatType == QgsWkbTypes.Type.Polygon:
             rings = geom.asPolygon()
-        elif flatType == QgsWkbTypes.MultiPolygon:
+        elif flatType == QgsWkbTypes.Type.MultiPolygon:
             for poly in geom.asMultiPolygon():
                 rings.extend(poly)
         parts = [QgsGeometry.fromPolylineXY(ring) for ring in rings if ring]
@@ -1253,9 +1253,9 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
         """
         flatType = QgsWkbTypes.flatType(geom.wkbType())
         rings = []
-        if flatType == QgsWkbTypes.Polygon:
+        if flatType == QgsWkbTypes.Type.Polygon:
             rings = geom.asPolygon()
-        elif flatType == QgsWkbTypes.MultiPolygon:
+        elif flatType == QgsWkbTypes.Type.MultiPolygon:
             for poly in geom.asMultiPolygon():
                 rings.extend(poly)
 
@@ -1277,7 +1277,7 @@ class VerifyBDGExEdgeMatchingAlgorithm(ValidationAlgorithm):
         newFeat = QgsFeature(fields)
         newFeat.setGeometry(geom)
         newFeat["reason"] = reason
-        sink.addFeature(newFeat, QgsFeatureSink.FastInsert)
+        sink.addFeature(newFeat, QgsFeatureSink.Flag.FastInsert)
 
     # -------------------------------------------------------------------------
     # Standard QgsProcessingAlgorithm overrides

--- a/DsgTools/core/DbTools/dbConversionHandler.py
+++ b/DsgTools/core/DbTools/dbConversionHandler.py
@@ -102,12 +102,12 @@ class MappingFeatureProcessor(AbstractFeatureProcessor):
         self.mappingType = mappingType
         self.geometryHandler = GeometryHandler()
         self.geomWkbToStringTypeMap = {
-            QgsWkbTypes.Point: "POINT",
-            QgsWkbTypes.MultiPoint: "POINT",
-            QgsWkbTypes.LineString: "LINESTRING",
-            QgsWkbTypes.MultiLineString: "LINESTRING",
-            QgsWkbTypes.Polygon: "POLYGON",
-            QgsWkbTypes.MultiPolygon: "POLYGON",
+            QgsWkbTypes.Type.Point: "POINT",
+            QgsWkbTypes.Type.MultiPoint: "POINT",
+            QgsWkbTypes.Type.LineString: "LINESTRING",
+            QgsWkbTypes.Type.MultiLineString: "LINESTRING",
+            QgsWkbTypes.Type.Polygon: "POLYGON",
+            QgsWkbTypes.Type.MultiPolygon: "POLYGON",
         }
 
     def buildFileDict(self, mappingPath: str) -> dict:

--- a/DsgTools/core/DbTools/dbConverter.py
+++ b/DsgTools/core/DbTools/dbConverter.py
@@ -60,7 +60,7 @@ class DbConverter(QgsTask):
     """
 
     def __init__(
-        self, iface, conversionMap=None, description="", flags=QgsTask.CanCancel
+        self, iface, conversionMap=None, description="", flags=QgsTask.Flag.CanCancel
     ):
         """
         Class constructor.

--- a/DsgTools/core/Factories/LayerLoaderFactory/geopackageLayerLoader.py
+++ b/DsgTools/core/Factories/LayerLoaderFactory/geopackageLayerLoader.py
@@ -262,7 +262,7 @@ class GeopackageLayerLoader(EDGVLayerLoader):
             )
         QgsProject.instance().addMapLayer(vlayer, addToLegend=False)
         crs = QgsCoordinateReferenceSystem(
-            int(srid), QgsCoordinateReferenceSystem.EpsgCrsId
+            int(srid), QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
         )
         vlayer.setCrs(crs)
         vlayer = self.setDomainsAndRestrictionsWithQml(vlayer)

--- a/DsgTools/core/Factories/LayerLoaderFactory/postgisLayerLoader.py
+++ b/DsgTools/core/Factories/LayerLoaderFactory/postgisLayerLoader.py
@@ -278,7 +278,7 @@ class PostGISLayerLoader(EDGVLayerLoader):
         vlayer = QgsVectorLayer(self.uri.uri(), tableName, self.provider)
         QgsProject.instance().addMapLayer(vlayer, addToLegend=False)
         crs = QgsCoordinateReferenceSystem(
-            int(srid), QgsCoordinateReferenceSystem.EpsgCrsId
+            int(srid), QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
         )
         if vlayer is None:
             return vlayer

--- a/DsgTools/core/Factories/LayerLoaderFactory/shapefileLayerLoader.py
+++ b/DsgTools/core/Factories/LayerLoaderFactory/shapefileLayerLoader.py
@@ -187,7 +187,7 @@ class ShapefileLayerLoader(EDGVLayerLoader):
         vlayer = QgsVectorLayer(self.uri.uri(), tableName, self.provider)
         QgsProject.instance().addMapLayer(vlayer, addToLegend=False)
         crs = QgsCoordinateReferenceSystem(
-            int(srid), QgsCoordinateReferenceSystem.EpsgCrsId
+            int(srid), QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
         )
         vlayer.setCrs(crs)
         vlayer = self.setDomainsAndRestrictionsWithQml(vlayer)

--- a/DsgTools/core/GeometricTools/geometryHandler.py
+++ b/DsgTools/core/GeometricTools/geometryHandler.py
@@ -44,14 +44,14 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QObject
 
 geometry_creation_dict = {
-    QgsWkbTypes.Point: lambda x: QgsGeometry.fromPointXY(x),
-    QgsWkbTypes.MultiPoint: lambda x: QgsGeometry.fromMultiPointXY(x),
-    QgsWkbTypes.LineString: lambda x: QgsGeometry.fromPolylineXY(x),
-    QgsWkbTypes.MultiLineString: lambda x: QgsGeometry.fromMultiPolylineXY(
+    QgsWkbTypes.Type.Point: lambda x: QgsGeometry.fromPointXY(x),
+    QgsWkbTypes.Type.MultiPoint: lambda x: QgsGeometry.fromMultiPointXY(x),
+    QgsWkbTypes.Type.LineString: lambda x: QgsGeometry.fromPolylineXY(x),
+    QgsWkbTypes.Type.MultiLineString: lambda x: QgsGeometry.fromMultiPolylineXY(
         [QgsPointXY(*i) for i in x]
     ),
-    QgsWkbTypes.Polygon: lambda x: QgsGeometry.fromPolygonXY([x]),
-    QgsWkbTypes.MultiPolygon: lambda x: QgsGeometry.fromMultiPolygonXY([x]),
+    QgsWkbTypes.Type.Polygon: lambda x: QgsGeometry.fromPolygonXY([x]),
+    QgsWkbTypes.Type.MultiPolygon: lambda x: QgsGeometry.fromMultiPolygonXY([x]),
 }
 
 

--- a/DsgTools/core/GeometricTools/layerHandler.py
+++ b/DsgTools/core/GeometricTools/layerHandler.py
@@ -2397,7 +2397,7 @@ class LayerHandler(QObject):
             centroidLyr, inputLyr, context, feedback=multiStepFeedback
         )
         for feat in centroidsWithAttributes.getFeatures():
-            outputCenterPointSink.addFeature(feat, QgsFeatureSink.FastInsert)
+            outputCenterPointSink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
 
     def filterEdges(
         self,
@@ -2453,7 +2453,7 @@ class LayerHandler(QObject):
             for feat in outputSet:
                 if feat in notBoundarySet:
                     continue
-                outputBoundarySink.addFeature(feat, QgsFeatureSink.FastInsert)
+                outputBoundarySink.addFeature(feat, QgsFeatureSink.Flag.FastInsert)
             if multiStepFeedback is not None:
                 multiStepFeedback.setProgress(current * stepSize)
 

--- a/DsgTools/core/Misc/QGIS_Scripts/virtual_raster_inloco.py
+++ b/DsgTools/core/Misc/QGIS_Scripts/virtual_raster_inloco.py
@@ -54,7 +54,8 @@ def createVrt(inventario, vrt):
         if Override_CRS:
             raster.setCrs(
                 QgsCoordinateReferenceSystem(
-                    int(CRS.split(":")[-1]), QgsCoordinateReferenceSystem.EpsgCrsId
+                    int(CRS.split(":")[-1]),
+                    QgsCoordinateReferenceSystem.CrsType.EpsgCrsId,
                 )
             )
 

--- a/DsgTools/core/Misc/QmlTools/qml_creator.py
+++ b/DsgTools/core/Misc/QmlTools/qml_creator.py
@@ -7,7 +7,7 @@ def generateQml(filename, attrs, codelists):
     xmlWriter = QXmlStreamWriter()
     xmlFile = QFile(filename)
 
-    if xmlFile.open(QIODevice.WriteOnly) == False:
+    if xmlFile.open(QIODevice.OpenModeFlag.WriteOnly) == False:
         QMessageBox.warning(
             0,
             QCoreApplication.translate("QmlCreator", "Error!"),

--- a/DsgTools/gui/CustomWidgets/AdvancedInterfaceWidgets/auxLayerSelector.py
+++ b/DsgTools/gui/CustomWidgets/AdvancedInterfaceWidgets/auxLayerSelector.py
@@ -57,7 +57,7 @@ class AuxLayerSelector(QWidget):
         """
         returnDict = dict()
         for i in range(self.layout.rowCount()):
-            key = self.layout.itemAt(i, QFormLayout.LabelRole).text()
-            value = self.layout.itemAt(i, QFormLayout.FieldRole).currentText()
+            key = self.layout.itemAt(i, QFormLayout.ItemRole.LabelRole).text()
+            value = self.layout.itemAt(i, QFormLayout.ItemRole.FieldRole).currentText()
             returnDict[key] = value
         return returnDict

--- a/DsgTools/gui/CustomWidgets/ConnectionWidgets/connectionWidget.py
+++ b/DsgTools/gui/CustomWidgets/ConnectionWidgets/connectionWidget.py
@@ -177,7 +177,7 @@ class ConnectionWidget(QtWidgets.QWidget, FORM_CLASS):
                 )
             else:
                 self.crs = QgsCoordinateReferenceSystem(
-                    self.epsg, QgsCoordinateReferenceSystem.EpsgCrsId
+                    self.epsg, QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
                 )
                 self.postGISCrsEdit.setText(self.crs.description())
                 self.postGISCrsEdit.setReadOnly(True)

--- a/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiGeopackageSelectorWidget.py
+++ b/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiGeopackageSelectorWidget.py
@@ -55,7 +55,7 @@ class MultiGeopackageSelectorWidget(AbstractMultiDsSelectorWidget):
         """
         return os.path.basename(datasourcePath).split(".")[0]
 
-    def exec_(self):
+    def exec(self):
         """
         Starts dialog.
         """

--- a/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiPostgisSelectorWidget.py
+++ b/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiPostgisSelectorWidget.py
@@ -226,7 +226,7 @@ class MultiPostgisSelectorWidget(AbstractMultiDsSelectorWidget):
         serverInfo.insert(0, self.selector.serverName)
         return {dbname: serverInfo for dbname in dbList}
 
-    def exec_(self):
+    def exec(self):
         """
         Executes selector dialog and updates selected databases, if any database is selected.
         :return: (int) execution code.

--- a/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiShapefileSelectorWidget.py
+++ b/DsgTools/gui/CustomWidgets/DatabaseConversionWidgets/MultiDsSelectorWidgets/SupportedDrivers/multiShapefileSelectorWidget.py
@@ -55,7 +55,7 @@ class MultiShapefileSelectorWidget(AbstractMultiDsSelectorWidget):
         """
         return os.path.basename(datasourcePath).split(".")[0]
 
-    def exec_(self):
+    def exec(self):
         """
         Starts dialog.
         """

--- a/DsgTools/gui/Misc/ImageTools/processingTools.py
+++ b/DsgTools/gui/Misc/ImageTools/processingTools.py
@@ -57,7 +57,7 @@ class ProcessingTools(QtWidgets.QDialog, FORM_CLASS):
 
         self.epsg = 4326
         srs = QgsCoordinateReferenceSystem(
-            self.epsg, QgsCoordinateReferenceSystem.EpsgCrsId
+            self.epsg, QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
         )
         self.srLineEdit.setText(srs.description())
 
@@ -124,7 +124,7 @@ class ProcessingTools(QtWidgets.QDialog, FORM_CLASS):
         else:
             self.epsg = int(projSelector.selectedAuthId().split(":")[-1])
         srs = QgsCoordinateReferenceSystem(
-            self.epsg, QgsCoordinateReferenceSystem.EpsgCrsId
+            self.epsg, QgsCoordinateReferenceSystem.CrsType.EpsgCrsId
         )
         self.srLineEdit.setText(srs.description())
 

--- a/DsgTools/gui/Misc/ProcessingTools/processManager.py
+++ b/DsgTools/gui/Misc/ProcessingTools/processManager.py
@@ -228,12 +228,12 @@ class ProcessManager(QObject):
             actions = layer.actions()
             field = '[% "fileName" %]'
             actions.addAction(
-                QgsAction.GenericPython,
+                QgsAction.ActionType.GenericPython,
                 "Load Vector Layer",
                 "qgis.utils.iface.addVectorLayer(r'%s', 'File', 'ogr')" % field,
             )
             actions.addAction(
-                QgsAction.GenericPython,
+                QgsAction.ActionType.GenericPython,
                 "Load Raster Layer",
                 "qgis.utils.iface.addRasterLayer(r'%s', 'File')" % field,
             )

--- a/DsgTools/gui/ProductionTools/MapTools/Acquisition/geometricaAquisition.py
+++ b/DsgTools/gui/ProductionTools/MapTools/Acquisition/geometricaAquisition.py
@@ -274,7 +274,7 @@ class GeometricaAcquisition(QgsMapTool):
         rubberBand.setFillColor(QColor(255, 0, 0, 40))
         rubberBand.setSecondaryStrokeColor(QColor(255, 0, 0, 200))
         rubberBand.setWidth(2)
-        rubberBand.setIcon(QgsRubberBand.ICON_X)
+        rubberBand.setIcon(QgsRubberBand.IconType.ICON_X)
         return rubberBand
 
     def setAllowedStyleSnapRubberBand(self):

--- a/DsgTools/gui/ProductionTools/MapTools/AuxTools/closeLinesTool.py
+++ b/DsgTools/gui/ProductionTools/MapTools/AuxTools/closeLinesTool.py
@@ -183,8 +183,8 @@ class CloseLinesTool(QgsMapTool):
         # Parâmetro de entrada: geometry ( QgsGeometry ), tolerance ( float )
 
         if not geometry.wkbType() in (
-            QgsWkbTypes.LineString,
-            QgsWkbTypes.MultiLineString,
+            QgsWkbTypes.Type.LineString,
+            QgsWkbTypes.Type.MultiLineString,
         ):
             return False
         if geometry.isNull() or geometry.isEmpty():
@@ -205,8 +205,8 @@ class CloseLinesTool(QgsMapTool):
 
     def snapLastPointToFirstPoint(self, geometry: QgsGeometry):
         if not geometry.wkbType() in (
-            QgsWkbTypes.LineString,
-            QgsWkbTypes.MultiLineString,
+            QgsWkbTypes.Type.LineString,
+            QgsWkbTypes.Type.MultiLineString,
         ):
             return geometry
         if geometry.isMultipart():
@@ -235,8 +235,8 @@ class CloseLinesTool(QgsMapTool):
     def splitLine(self, layer, feature) -> Set[QgsFeature]:
         geometry = feature.geometry()
         if not geometry.wkbType() in (
-            QgsWkbTypes.LineString,
-            QgsWkbTypes.MultiLineString,
+            QgsWkbTypes.Type.LineString,
+            QgsWkbTypes.Type.MultiLineString,
         ):
             return feature, None
         if geometry.isMultipart():

--- a/DsgTools/gui/ProductionTools/MapTools/FreeHandTool/models/acquisitionFree.py
+++ b/DsgTools/gui/ProductionTools/MapTools/FreeHandTool/models/acquisitionFree.py
@@ -349,7 +349,7 @@ class AcquisitionFree(gui.QgsMapTool):
             if length != None or length == 0:
                 measure_dist = self.dist_area.measureLength(geom)
                 dist = self.dist_area.convertLengthMeasurement(
-                    measure_dist, QgsUnitTypes.DistanceMeters
+                    measure_dist, QgsUnitTypes.DistanceUnit.DistanceMeters
                 )
                 # Tr
                 txt = (
@@ -369,7 +369,7 @@ class AcquisitionFree(gui.QgsMapTool):
             if area != None or area == 0:
                 measure_dist = self.dist_area.measureArea(geom)
                 dist = self.dist_area.convertAreaMeasurement(
-                    measure_dist, QgsUnitTypes.AreaSquareMeters
+                    measure_dist, QgsUnitTypes.AreaUnit.AreaSquareMeters
                 )
                 # Tr
                 txt = (

--- a/DsgTools/gui/ProductionTools/MapTools/GenericSelectionTool/genericSelectionTool.py
+++ b/DsgTools/gui/ProductionTools/MapTools/GenericSelectionTool/genericSelectionTool.py
@@ -625,7 +625,9 @@ class GenericSelectionTool(AbstractSelectionTool):
                     continue
                 # builds bbRect and select from layer, adding selection
                 bbRect = self.canvas.mapSettings().mapToLayerCoordinates(layer, r)
-                layer.selectByRect(bbRect, behavior=QgsVectorLayer.AddToSelection)
+                layer.selectByRect(
+                    bbRect, behavior=QgsVectorLayer.SelectBehavior.AddToSelection
+                )
             self.rubberBand.hide()
 
     def setSelectionFeature(

--- a/DsgTools/gui/ProductionTools/MapTools/MeasureTool/measureTool.py
+++ b/DsgTools/gui/ProductionTools/MapTools/MeasureTool/measureTool.py
@@ -243,13 +243,13 @@ class EventFilter(QObject):
             line_acum = QgsGeometry.fromPolylineXY(self.pointList)
             measure_distAcum = self.dist_area.measureLength(line_acum)
             distAcum = self.dist_area.convertLengthMeasurement(
-                measure_distAcum, QgsUnitTypes.DistanceMeters
+                measure_distAcum, QgsUnitTypes.DistanceUnit.DistanceMeters
             )
             tooltip = QToolTip
             if length != None or length == 0:
                 measure_dist = self.dist_area.measureLength(line_dist)
                 dist = self.dist_area.convertLengthMeasurement(
-                    measure_dist, QgsUnitTypes.DistanceMeters
+                    measure_dist, QgsUnitTypes.DistanceUnit.DistanceMeters
                 )
                 txt = "<b>{partial} {dist:.3f} m</b><br/><b>{total} {distAcum:.3f} m</b></p>".format(
                     partial=self.tr("Partial:"),
@@ -279,7 +279,7 @@ class EventFilter(QObject):
             if area != None:
                 measure_area = self.dist_area.measureArea(polygon)
                 area = self.dist_area.convertAreaMeasurement(
-                    measure_area, QgsUnitTypes.AreaSquareMeters
+                    measure_area, QgsUnitTypes.AreaUnit.AreaSquareMeters
                 )
                 txt = f"<b>Area: {area:.3f}m²</b></p>"
                 QToolTip.showText(

--- a/DsgTools/gui/ProductionTools/Toolbars/InspectFeatures/inspectFeatures.py
+++ b/DsgTools/gui/ProductionTools/Toolbars/InspectFeatures/inspectFeatures.py
@@ -236,7 +236,7 @@ class InspectFeatures(QWidget, Ui_Form):
             )
             return []
         request = QgsFeatureRequest()
-        request.setFlags(QgsFeatureRequest.NoGeometry)
+        request.setFlags(QgsFeatureRequest.Flag.NoGeometry)
         if self.mFieldExpressionWidget.currentText() != "":
             request.setFilterExpression(self.mFieldExpressionWidget.asExpression())
         clauseList = []


### PR DESCRIPTION
Quarto bloqueio da release 5.2.0 no scanner do OSGeo: 722 issues de compatibilidade Qt6, quase todo `Enum error, add 'X' before 'Y'` (acesso direto `Classe.Valor` que precisa virar `Classe.EnumAninhado.Valor`). Não é só `QgsWkbTypes` -- afeta 15+ classes da API do QGIS. Detalhe completo e tabela de padrões no `CLAUDE.md` (corrigi uma entrada antiga que dizia o contrário sobre `QgsWkbTypes`).

718 enums corrigidos com fixer mecânico (coluna do scanner + nome do enum já dado na mensagem), + 3 métodos `exec_` renomeados pra `exec`, + 1 `QVariant() ==` trocado por `NULL`.

Testado pelo usuário em servidor remoto antes deste PR -- funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)